### PR TITLE
Remove static method at subclass of ManagedTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ When you send transactions, `caver-java` provides easy-to-use wrapper classes. H
 ```java
 Caver caver = Caver.build(<endpoint>);
 KlayCredentials credentials = KlayWalletUtils.loadCredentials(<password>, <walletfilePath>);
-KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.sendFunds(
-            caver, credentials, <address>, 
-            <value>, <valueUnit>, <gasLimit>)
-            .send();
+KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.create(caver, credentials).sendFunds(
+            <address>, <value>, <valueUnit>, <gasLimit>
+            ).send();
 ```
 `<valueUnit>` means a unit of value that is used in Klaytn. It is defined as an enum type. Examples of possible values are as below.
 
@@ -191,7 +190,7 @@ KlayCredentials credentials = KlayWalletUtils.loadCredentials(<password>, <filep
                                                       
 /* Value Transfer */
 TransactionReceipt transactionReceipt = Transfer.sendFunds(...),send(); // Web3j
-KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.sendFunds().send(); // caver-java
+KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.create(...).sendFunds(...).send(); // caver-java
 ```
 
 ## Command-line Tool

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ When you send transactions, `caver-java` provides easy-to-use wrapper classes. H
 ```java
 Caver caver = Caver.build(<endpoint>);
 KlayCredentials credentials = KlayWalletUtils.loadCredentials(<password>, <walletfilePath>);
-KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.create(caver, credentials).sendFunds(
+int chainId = ChainId.BAOBAB_TESTNET; // ChainId.BAOBAB_TESTNET = 1001
+KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.create(caver, credentials, chainId).sendFunds(
             <fromAddress>, <toAddress>, <value>, <valueUnit>, <gasLimit>
-            ).send();
+        ).send();
 ```
 `<valueUnit>` means a unit of value that is used in Klaytn. It is defined as an enum type. Examples of possible values are as below.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When you send transactions, `caver-java` provides easy-to-use wrapper classes. H
 Caver caver = Caver.build(<endpoint>);
 KlayCredentials credentials = KlayWalletUtils.loadCredentials(<password>, <walletfilePath>);
 KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.create(caver, credentials).sendFunds(
-            <address>, <value>, <valueUnit>, <gasLimit>
+            <fromAddress>, <toAddress>, <value>, <valueUnit>, <gasLimit>
             ).send();
 ```
 `<valueUnit>` means a unit of value that is used in Klaytn. It is defined as an enum type. Examples of possible values are as below.

--- a/core/src/main/java/com/klaytn/caver/tx/Account.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Account.java
@@ -42,8 +42,9 @@ public class Account extends ManagedTransaction {
         return new Account(caver, transactionManager);
     }
 
-    public static Account create(Caver caver, KlayCredentials klayCredentials) {
+    public static Account create(Caver caver, KlayCredentials klayCredentials, int chainId) {
         TransactionManager transactionManager = new TransactionManager.Builder(caver, klayCredentials)
+                .setChaindId(chainId)
                 .build();
 
         return Account.create(caver, transactionManager);

--- a/core/src/main/java/com/klaytn/caver/tx/Account.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Account.java
@@ -29,28 +29,23 @@ import com.klaytn.caver.tx.model.AccountUpdateTransaction;
 import org.web3j.protocol.core.RemoteCall;
 
 public class Account extends ManagedTransaction {
-    public Account(Caver caver, TransactionManager transactionManager) {
+
+    private Account(Caver caver, TransactionManager transactionManager) {
         super(caver, transactionManager);
-    }
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendUpdateTransaction(
-            Caver caver, KlayCredentials credentials, AccountUpdateTransaction transaction) {
-
-        return Account.sendUpdateTransaction(caver, credentials, transaction, null);
-    }
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendUpdateTransaction(
-            Caver caver, KlayCredentials credentials, AccountUpdateTransaction transaction, ErrorHandler errorHandler) {
-
-        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
-                .setErrorHandler(errorHandler)
-                .build();
-
-        return new RemoteCall<>(() ->
-                new Account(caver, transactionManager).send(transaction));
     }
 
     public RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendUpdateTransaction(AccountUpdateTransaction transaction) {
         return new RemoteCall<>(() -> send(transaction));
+    }
+
+    public static Account create(Caver caver, TransactionManager transactionManager) {
+        return new Account(caver, transactionManager);
+    }
+
+    public static Account create(Caver caver, KlayCredentials klayCredentials) {
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, klayCredentials)
+                .build();
+
+        return Account.create(caver, transactionManager);
     }
 }

--- a/core/src/main/java/com/klaytn/caver/tx/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Cancel.java
@@ -29,30 +29,23 @@ import com.klaytn.caver.tx.model.CancelTransaction;
 import org.web3j.protocol.core.RemoteCall;
 
 public class Cancel extends ManagedTransaction {
-    public Cancel(Caver caver, TransactionManager transactionManager) {
+
+    private Cancel(Caver caver, TransactionManager transactionManager) {
         super(caver, transactionManager);
     }
 
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendCancelTransaction(
-            Caver caver, KlayCredentials credentials, CancelTransaction transaction) {
-
-        return Cancel.sendCancelTransaction(caver, credentials, transaction, null);
-    }
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendCancelTransaction(
-            Caver caver, KlayCredentials credentials, CancelTransaction transaction, ErrorHandler errorHandler) {
-
-        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
-                .setErrorHandler(errorHandler)
-                .build();
-
-        return new RemoteCall<>(() ->
-                new Cancel(caver, transactionManager).send(transaction));
-    }
-
-
     public RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendCancelTransaction(CancelTransaction transaction) {
         return new RemoteCall<>(() -> send(transaction));
+    }
+
+    public static Cancel create(Caver caver, TransactionManager transactionManager) {
+        return new Cancel(caver, transactionManager);
+    }
+
+    public static Cancel create(Caver caver, KlayCredentials klayCredentials) {
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, klayCredentials)
+                .build();
+
+        return Cancel.create(caver, transactionManager);
     }
 }

--- a/core/src/main/java/com/klaytn/caver/tx/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Cancel.java
@@ -42,8 +42,9 @@ public class Cancel extends ManagedTransaction {
         return new Cancel(caver, transactionManager);
     }
 
-    public static Cancel create(Caver caver, KlayCredentials klayCredentials) {
+    public static Cancel create(Caver caver, KlayCredentials klayCredentials, int chainId) {
         TransactionManager transactionManager = new TransactionManager.Builder(caver, klayCredentials)
+                .setChaindId(chainId)
                 .build();
 
         return Cancel.create(caver, transactionManager);

--- a/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
+++ b/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
@@ -334,23 +334,6 @@ public class SmartContract extends ManagedTransaction {
         return new RemoteCall<>(() -> executeTransaction(function, weiValue));
     }
 
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(
-            Caver caver, KlayCredentials credentials, SmartContractExecutionTransaction transaction) {
-
-        return SmartContract.sendExecutionTransaction(caver, credentials, transaction, null);
-    }
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(
-            Caver caver, KlayCredentials credentials, SmartContractExecutionTransaction transaction, ErrorHandler errorHandler) {
-
-        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
-                .setErrorHandler(errorHandler)
-                .build();
-
-        return new RemoteCall<>(() ->
-                new SmartContract(caver, transactionManager).send(transaction));
-    }
-
     public RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(SmartContractExecutionTransaction transaction) {
         return new RemoteCall<>(() -> send(transaction));
     }

--- a/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
@@ -23,7 +23,6 @@ package com.klaytn.caver.tx;
 import com.klaytn.caver.Caver;
 import com.klaytn.caver.crpyto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
-import com.klaytn.caver.tx.manager.ErrorHandler;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import com.klaytn.caver.utils.Convert;
 import com.klaytn.caver.tx.model.ValueTransferTransaction;
@@ -37,7 +36,7 @@ public class ValueTransfer extends ManagedTransaction {
 
     public static final BigInteger GAS_LIMIT = BigInteger.valueOf(21000);
 
-    public ValueTransfer(Caver caver, TransactionManager transactionManager) {
+    private ValueTransfer(Caver caver, TransactionManager transactionManager) {
         super(caver, transactionManager);
     }
 
@@ -58,40 +57,6 @@ public class ValueTransfer extends ManagedTransaction {
         return send(transaction);
     }
 
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
-            Caver caver, KlayCredentials credentials, String toAddress, BigDecimal value, Convert.Unit unit, BigInteger gasLimit) {
-
-        return ValueTransfer.sendFunds(caver, credentials, toAddress, value, unit, gasLimit, null);
-    }
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
-            Caver caver, KlayCredentials credentials, String toAddress, BigDecimal value, Convert.Unit unit, BigInteger gasLimit, ErrorHandler errorHandler) {
-
-        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
-                .setErrorHandler(errorHandler)
-                .build();
-
-        return new RemoteCall<>(() ->
-                new ValueTransfer(caver, transactionManager).send(credentials.getAddress(), toAddress, value, unit, gasLimit));
-    }
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
-            Caver caver, KlayCredentials credentials, ValueTransferTransaction transaction) {
-
-        return ValueTransfer.sendFunds(caver, credentials, transaction, null);
-    }
-
-    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
-            Caver caver, KlayCredentials credentials, ValueTransferTransaction transaction, ErrorHandler errorHandler) {
-
-        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
-                .setErrorHandler(errorHandler)
-                .build();
-
-        return new RemoteCall<>(() ->
-                new ValueTransfer(caver, transactionManager).send(transaction));
-    }
-
     public RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
             String fromAddress, String toAddress, BigDecimal value, Convert.Unit unit, BigInteger gasLimit) {
         return new RemoteCall<>(() -> send(fromAddress, toAddress, value, unit, gasLimit));
@@ -99,5 +64,16 @@ public class ValueTransfer extends ManagedTransaction {
 
     public RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(ValueTransferTransaction transaction) {
         return new RemoteCall<>(() -> send(transaction));
+    }
+
+    public static ValueTransfer create(Caver caver, TransactionManager transactionManager) {
+        return new ValueTransfer(caver, transactionManager);
+    }
+
+    public static ValueTransfer create(Caver caver, KlayCredentials klayCredentials) {
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, klayCredentials)
+                .build();
+
+        return ValueTransfer.create(caver, transactionManager);
     }
 }

--- a/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
@@ -70,8 +70,9 @@ public class ValueTransfer extends ManagedTransaction {
         return new ValueTransfer(caver, transactionManager);
     }
 
-    public static ValueTransfer create(Caver caver, KlayCredentials klayCredentials) {
+    public static ValueTransfer create(Caver caver, KlayCredentials klayCredentials, int chainId) {
         TransactionManager transactionManager = new TransactionManager.Builder(caver, klayCredentials)
+                .setChaindId(chainId)
                 .build();
 
         return ValueTransfer.create(caver, transactionManager);

--- a/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
@@ -123,7 +123,7 @@ public class ManagedTransactionTest {
     public void testAccountUpdate() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
 
-        ValueTransfer.create(caver, BRANDON).sendFunds(
+        ValueTransfer.create(caver, BRANDON, ChainId.BAOBAB_TESTNET).sendFunds(
                 BRANDON.getAddress(),
                 credentials.getAddress(),
                 BigDecimal.valueOf(0.2),
@@ -140,7 +140,7 @@ public class ManagedTransactionTest {
     public void testUpdateFlow() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
 
-        ValueTransfer.create(caver, BRANDON).sendFunds(
+        ValueTransfer.create(caver, BRANDON, ChainId.BAOBAB_TESTNET).sendFunds(
                 BRANDON.getAddress(),
                 credentials.getAddress(),
                 BigDecimal.valueOf(0.2),
@@ -159,7 +159,7 @@ public class ManagedTransactionTest {
     public void testUpdateFuture() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
 
-        ValueTransfer.create(caver, BRANDON).sendFunds(
+        ValueTransfer.create(caver, BRANDON, ChainId.BAOBAB_TESTNET).sendFunds(
                 BRANDON.getAddress(),
                 credentials.getAddress(),
                 BigDecimal.valueOf(0.2),

--- a/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
@@ -28,6 +28,7 @@ import com.klaytn.caver.tx.manager.TransactionManager;
 import com.klaytn.caver.tx.model.AccountUpdateTransaction;
 import com.klaytn.caver.tx.model.SmartContractDeployTransaction;
 import com.klaytn.caver.tx.model.SmartContractExecutionTransaction;
+import com.klaytn.caver.utils.ChainId;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Convert;
 import com.klaytn.caver.wallet.WalletManager;
@@ -218,4 +219,14 @@ public class ManagedTransactionTest {
         assertEquals("0x1", receipt.getStatus());
     }
 
+    @Test
+    public void testValueTransferChainId() throws Exception {
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, LUMAN)
+                .setChaindId(ChainId.BAOBAB_TESTNET)
+                .build();
+
+        ValueTransfer valueTransfer = ValueTransfer.create(caver, transactionManager);
+        KlayTransactionReceipt.TransactionReceipt transactionReceipt = valueTransfer.sendFunds(LUMAN.getAddress(), BRANDON.getAddress(), BigDecimal.ONE, Convert.Unit.PEB, GAS_LIMIT).send();
+        assertEquals("0x1", transactionReceipt.getStatus());
+    }
 }

--- a/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
@@ -28,7 +28,6 @@ import com.klaytn.caver.tx.manager.TransactionManager;
 import com.klaytn.caver.tx.model.AccountUpdateTransaction;
 import com.klaytn.caver.tx.model.SmartContractDeployTransaction;
 import com.klaytn.caver.tx.model.SmartContractExecutionTransaction;
-import com.klaytn.caver.tx.model.ValueTransferTransaction;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Convert;
 import com.klaytn.caver.wallet.WalletManager;
@@ -51,7 +50,6 @@ public class ManagedTransactionTest {
     private final BigInteger GAS_LIMIT = BigInteger.valueOf(4_300_000);
     private TransactionManager transactionManager;
 
-    private ValueTransferTransaction valueTransferTransaction;
     private SmartContractDeployTransaction smartContractDeployTransaction;
     private SmartContractExecutionTransaction smartContractExecutionTransaction;
 
@@ -60,9 +58,6 @@ public class ManagedTransactionTest {
         caver = Caver.build(Caver.BAOBAB_URL);
 
         this.transactionManager = getTransactionManager(LUMAN);
-
-        this.valueTransferTransaction = ValueTransferTransaction
-                .create(LUMAN.getAddress(), WAYNE.getAddress(), BigInteger.ZERO, BigInteger.valueOf(1000000));
 
         byte[] payload = Numeric.hexStringToByteArray("0x60806040526000805534801561001457600080fd5b50610116806100246000396000f3006080604052600436106053576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd14605857806342cbb15c146080578063d14e62b81460a8575b600080fd5b348015606357600080fd5b50606a60d2565b6040518082815260200191505060405180910390f35b348015608b57600080fd5b50609260d8565b6040518082815260200191505060405180910390f35b34801560b357600080fd5b5060d06004803603810190808035906020019092919050505060e0565b005b60005481565b600043905090565b80600081905550505600a165627a7a7230582064856de85a2706463526593b08dd790054536042ef66d3204018e6790a2208d10029");
         this.smartContractDeployTransaction = SmartContractDeployTransaction
@@ -102,14 +97,14 @@ public class ManagedTransactionTest {
 
     @Test
     public void testValueTransfer() throws Exception {
-        ValueTransfer valueTransfer = new ValueTransfer(caver, transactionManager);
+        ValueTransfer valueTransfer = ValueTransfer.create(caver, transactionManager);
         KlayTransactionReceipt.TransactionReceipt transactionReceipt = valueTransfer.sendFunds(LUMAN.getAddress(), WAYNE.getAddress(), BigDecimal.ONE, Convert.Unit.PEB, GAS_LIMIT).send();
         assertEquals("0x1", transactionReceipt.getStatus());
     }
 
     @Test
     public void testValueTransferFlow() {
-        ValueTransfer valueTransfer = new ValueTransfer(caver, transactionManager);
+        ValueTransfer valueTransfer = ValueTransfer.create(caver, transactionManager);
         valueTransfer.sendFunds(LUMAN.getAddress(), WAYNE.getAddress(), BigDecimal.ONE, Convert.Unit.PEB, GAS_LIMIT).flowable()
                 .test()
                 .assertSubscribed()
@@ -118,38 +113,24 @@ public class ManagedTransactionTest {
 
     @Test
     public void testValueTransferFuture() throws ExecutionException, InterruptedException {
-        ValueTransfer valueTransfer = new ValueTransfer(caver, transactionManager);
+        ValueTransfer valueTransfer = ValueTransfer.create(caver, transactionManager);
         KlayTransactionReceipt.TransactionReceipt receipt = valueTransfer.sendFunds(LUMAN.getAddress(), WAYNE.getAddress(), BigDecimal.ONE, Convert.Unit.PEB, GAS_LIMIT).sendAsync().get();
         assertEquals("0x1", receipt.getStatus());
     }
 
     @Test
-    public void testValueTransferStatic() throws Exception {
-        KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.sendFunds(caver, LUMAN, valueTransferTransaction).send();
-        assertEquals("0x1", transactionReceipt.getStatus());
-    }
-
-    @Test
-    public void testValueTransferStaticFlow() {
-        ValueTransfer.sendFunds(caver, LUMAN, valueTransferTransaction).flowable()
-                .test()
-                .assertSubscribed()
-                .assertValue(receipt -> receipt.getStatus().equals("0x1"));
-    }
-
-    @Test
-    public void testValueTransferStaticFuture() throws ExecutionException, InterruptedException {
-        KlayTransactionReceipt.TransactionReceipt transactionReceipt = ValueTransfer.sendFunds(caver, LUMAN, valueTransferTransaction).sendAsync().get();
-        assertEquals("0x1", transactionReceipt.getStatus());
-    }
-
-    @Test
     public void testAccountUpdate() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
+
+        ValueTransfer.create(caver, BRANDON).sendFunds(
+                BRANDON.getAddress(),
+                credentials.getAddress(),
+                BigDecimal.valueOf(0.2),
+                Convert.Unit.KLAY, GAS_LIMIT
+        ).send();
 
         KlayCredentials updateCredential = KlayCredentials.create(Keys.createEcKeyPair());
-        Account updateAccount = new Account(caver, getTransactionManager(credentials));
+        Account updateAccount = Account.create(caver, getTransactionManager(credentials));
         KlayTransactionReceipt.TransactionReceipt transactionReceipt = updateAccount.sendUpdateTransaction(getAccountUpdateTransaction(credentials, updateCredential)).send();
         assertEquals("0x1", transactionReceipt.getStatus());
     }
@@ -157,10 +138,16 @@ public class ManagedTransactionTest {
     @Test
     public void testUpdateFlow() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
+
+        ValueTransfer.create(caver, BRANDON).sendFunds(
+                BRANDON.getAddress(),
+                credentials.getAddress(),
+                BigDecimal.valueOf(0.2),
+                Convert.Unit.KLAY, GAS_LIMIT
+        ).send();
 
         KlayCredentials updateCredential = KlayCredentials.create(Keys.createEcKeyPair());
-        Account updateAccount = new Account(caver, getTransactionManager(credentials));
+        Account updateAccount = Account.create(caver, getTransactionManager(credentials));
         updateAccount.sendUpdateTransaction(getAccountUpdateTransaction(credentials, updateCredential)).flowable()
                 .test()
                 .assertSubscribed()
@@ -170,43 +157,17 @@ public class ManagedTransactionTest {
     @Test
     public void testUpdateFuture() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
+
+        ValueTransfer.create(caver, BRANDON).sendFunds(
+                BRANDON.getAddress(),
+                credentials.getAddress(),
+                BigDecimal.valueOf(0.2),
+                Convert.Unit.KLAY, GAS_LIMIT
+        ).send();
 
         KlayCredentials updateCredential = KlayCredentials.create(Keys.createEcKeyPair());
-        Account updateAccount = new Account(caver, getTransactionManager(credentials));
+        Account updateAccount = Account.create(caver, getTransactionManager(credentials));
         KlayTransactionReceipt.TransactionReceipt transactionReceipt = updateAccount.sendUpdateTransaction(getAccountUpdateTransaction(credentials, updateCredential)).sendAsync().get();
-        assertEquals("0x1", transactionReceipt.getStatus());
-    }
-
-    @Test
-    public void testUpdateStatic() throws Exception {
-        KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
-
-        KlayCredentials updateCredential = KlayCredentials.create(Keys.createEcKeyPair());
-        KlayTransactionReceipt.TransactionReceipt transactionReceipt = Account.sendUpdateTransaction(caver, credentials, getAccountUpdateTransaction(credentials, updateCredential)).send();
-        assertEquals("0x1", transactionReceipt.getStatus());
-    }
-
-    @Test
-    public void testUpdateStaticFlow() throws Exception {
-        KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
-
-        KlayCredentials updateCredential = KlayCredentials.create(Keys.createEcKeyPair());
-        Account.sendUpdateTransaction(caver, credentials, getAccountUpdateTransaction(credentials, updateCredential)).flowable()
-                .test()
-                .assertSubscribed()
-                .assertValue(receipt -> receipt.getStatus().equals("0x1"));
-    }
-
-    @Test
-    public void testUpdateStaticFuture() throws Exception {
-        KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
-
-        KlayCredentials updateCredential = KlayCredentials.create(Keys.createEcKeyPair());
-        KlayTransactionReceipt.TransactionReceipt transactionReceipt = Account.sendUpdateTransaction(caver, credentials, getAccountUpdateTransaction(credentials, updateCredential)).sendAsync().get();
         assertEquals("0x1", transactionReceipt.getStatus());
     }
 
@@ -234,25 +195,6 @@ public class ManagedTransactionTest {
     }
 
     @Test
-    public void testSmartContractDeployStatic() throws Exception {
-        assertEquals("0x1", SmartContract.sendDeployTransaction(caver, LUMAN, smartContractDeployTransaction).send().getStatus());
-    }
-
-    @Test
-    public void testSmartContractDeployStaticFlow() {
-        SmartContract.sendDeployTransaction(caver, LUMAN, smartContractDeployTransaction).flowable()
-                .test()
-                .assertSubscribed()
-                .assertValue(receipt -> receipt.getStatus().equals("0x1"));
-    }
-
-    @Test
-    public void testSmartContractDeployStaticFuture() throws ExecutionException, InterruptedException {
-        KlayTransactionReceipt.TransactionReceipt receipt = SmartContract.sendDeployTransaction(caver, LUMAN, smartContractDeployTransaction).sendAsync().get();
-        assertEquals("0x1", receipt.getStatus());
-    }
-
-    @Test
     public void testSmartContractExecution() throws Exception {
         SmartContract smartContractExecution = new SmartContract(caver, transactionManager);
         KlayTransactionReceipt.TransactionReceipt receipt = smartContractExecution.sendExecutionTransaction(smartContractExecutionTransaction).send();
@@ -276,22 +218,4 @@ public class ManagedTransactionTest {
         assertEquals("0x1", receipt.getStatus());
     }
 
-    @Test
-    public void testSmartContractExecutionStatic() throws Exception {
-        assertEquals("0x1", SmartContract.sendExecutionTransaction(caver, LUMAN, smartContractExecutionTransaction).send().getStatus());
-    }
-
-    @Test
-    public void testSmartContractExecutionStaticFlow() {
-        SmartContract.sendExecutionTransaction(caver, LUMAN, smartContractExecutionTransaction).flowable()
-                .test()
-                .assertSubscribed()
-                .assertValue(receipt -> receipt.getStatus().equals("0x1"));
-    }
-
-    @Test
-    public void testSmartContractExecutionStaticFuture() throws ExecutionException, InterruptedException {
-        KlayTransactionReceipt.TransactionReceipt receipt = SmartContract.sendExecutionTransaction(caver, LUMAN, smartContractExecutionTransaction).sendAsync().get();
-        assertEquals("0x1", receipt.getStatus());
-    }
 }

--- a/core/src/test/java/com/klaytn/caver/feature/TransactionManagerTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/TransactionManagerTest.java
@@ -68,7 +68,8 @@ public class TransactionManagerTest {
     @Test
     public void testAccountUpdate() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
+        ValueTransfer.create(caver, BRANDON)
+                .sendFunds(BRANDON.getAddress(), credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
         TransactionManager updateTransactionManager = new TransactionManager.Builder(caver, credentials)
                 .setTransactionReceiptProcessor(new PollingTransactionReceiptProcessor(caver, 1000, 15))
                 .build();

--- a/core/src/test/java/com/klaytn/caver/feature/TransactionManagerTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/TransactionManagerTest.java
@@ -24,6 +24,7 @@ import com.klaytn.caver.tx.account.AccountKeyPublic;
 import com.klaytn.caver.tx.manager.PollingTransactionReceiptProcessor;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import com.klaytn.caver.tx.model.*;
+import com.klaytn.caver.utils.ChainId;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Convert;
 import com.klaytn.caver.wallet.WalletManager;
@@ -68,7 +69,7 @@ public class TransactionManagerTest {
     @Test
     public void testAccountUpdate() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.create(caver, BRANDON)
+        ValueTransfer.create(caver, BRANDON, ChainId.BAOBAB_TESTNET)
                 .sendFunds(BRANDON.getAddress(), credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
         TransactionManager updateTransactionManager = new TransactionManager.Builder(caver, credentials)
                 .setTransactionReceiptProcessor(new PollingTransactionReceiptProcessor(caver, 1000, 15))

--- a/core/src/test/java/com/klaytn/caver/scenario/AccountKeyIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/AccountKeyIT.java
@@ -44,7 +44,7 @@ public class AccountKeyIT extends Scenario {
     @Test
     public void AccountKeyRolebased() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.create(caver, BRANDON).sendFunds(
+        ValueTransfer.create(caver, BRANDON, BAOBAB_CHAIN_ID).sendFunds(
                 BRANDON.getAddress(),
                 credentials.getAddress(),
                 BigDecimal.valueOf(0.2),
@@ -56,7 +56,7 @@ public class AccountKeyIT extends Scenario {
                 credentials.getAddress(),
                 createRolebased(),
                 GAS_LIMIT);
-        KlayTransactionReceipt.TransactionReceipt receipt = Account.create(caver, credentials)
+        KlayTransactionReceipt.TransactionReceipt receipt = Account.create(caver, credentials, BAOBAB_CHAIN_ID)
                 .sendUpdateTransaction(accountUpdateTransaction)
                 .send();
         assertEquals("0x1", receipt.getStatus());

--- a/core/src/test/java/com/klaytn/caver/scenario/AccountKeyIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/AccountKeyIT.java
@@ -44,14 +44,21 @@ public class AccountKeyIT extends Scenario {
     @Test
     public void AccountKeyRolebased() throws Exception {
         KlayCredentials credentials = KlayCredentials.create(Keys.createEcKeyPair());
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.2), Convert.Unit.KLAY, GAS_LIMIT).send();
+        ValueTransfer.create(caver, BRANDON).sendFunds(
+                BRANDON.getAddress(),
+                credentials.getAddress(),
+                BigDecimal.valueOf(0.2),
+                Convert.Unit.KLAY, GAS_LIMIT
+        ).send();
         setUpAccount();
 
         AccountUpdateTransaction accountUpdateTransaction = AccountUpdateTransaction.create(
                 credentials.getAddress(),
                 createRolebased(),
                 GAS_LIMIT);
-        KlayTransactionReceipt.TransactionReceipt receipt = Account.sendUpdateTransaction(caver, credentials, accountUpdateTransaction).send();
+        KlayTransactionReceipt.TransactionReceipt receipt = Account.create(caver, credentials)
+                .sendUpdateTransaction(accountUpdateTransaction)
+                .send();
         assertEquals("0x1", receipt.getStatus());
     }
 

--- a/core/src/test/java/com/klaytn/caver/scenario/FastTransactionManagerIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/FastTransactionManagerIT.java
@@ -72,7 +72,7 @@ public class FastTransactionManagerIT extends Scenario {
                 })
                 .build();
 
-        ValueTransfer valueTransfer = new ValueTransfer(caver, transactionManager);
+        ValueTransfer valueTransfer = ValueTransfer.create(caver, transactionManager);
 
         for (int i = 0; i < COUNT; i++) {
             CompletableFuture<KlayTransactionReceipt.TransactionReceipt> transactionReceiptFuture = createTransaction(valueTransfer).sendAsync();
@@ -126,7 +126,7 @@ public class FastTransactionManagerIT extends Scenario {
                 .setTransactionReceiptProcessor(queuingTransactionReceiptProcessor)
                 .build();
 
-        ValueTransfer valueTransfer = new ValueTransfer(caver, transactionManager);
+        ValueTransfer valueTransfer = ValueTransfer.create(caver, transactionManager);
 
         for (int i = 0; i < COUNT; i++) {
             KlayTransactionReceipt.TransactionReceipt transactionReceipt = createTransaction(valueTransfer).send();

--- a/core/src/test/java/com/klaytn/caver/scenario/FeePayerManagerIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/FeePayerManagerIT.java
@@ -48,7 +48,7 @@ public class FeePayerManagerIT extends Scenario {
                 new File(KlayWalletUtils.getBaobabKeyDirectory())
         );
         KlayCredentials credentials = KlayWalletUtils.loadCredentials(PASSWORD, keystoreFilePath);
-        ValueTransfer.create(caver, BRANDON).sendFunds(
+        ValueTransfer.create(caver, BRANDON, BAOBAB_CHAIN_ID).sendFunds(
                 BRANDON.getAddress(),
                 credentials.getAddress(),
                 BigDecimal.valueOf(0.1),

--- a/core/src/test/java/com/klaytn/caver/scenario/FeePayerManagerIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/FeePayerManagerIT.java
@@ -48,7 +48,12 @@ public class FeePayerManagerIT extends Scenario {
                 new File(KlayWalletUtils.getBaobabKeyDirectory())
         );
         KlayCredentials credentials = KlayWalletUtils.loadCredentials(PASSWORD, keystoreFilePath);
-        ValueTransfer.sendFunds(caver, BRANDON, credentials.getAddress(), BigDecimal.valueOf(0.1), Convert.Unit.KLAY, GAS_LIMIT).send();
+        ValueTransfer.create(caver, BRANDON).sendFunds(
+                BRANDON.getAddress(),
+                credentials.getAddress(),
+                BigDecimal.valueOf(0.1),
+                Convert.Unit.KLAY, GAS_LIMIT
+        );
 
         SmartContractDeployTransaction smartContractDeploy = SmartContractDeployTransaction.create(
                 credentials.getAddress(),


### PR DESCRIPTION
## Proposed changes

- Remove static method at subclass of ManagedTransaction #5 
- If you want to add a chainID to a transaction. Use setChainId method of TransactionManger.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #5 

## Further comments
-