### PR TITLE
Added deprecated static methods at subclass of ManagedTransaction.

### DIFF
--- a/core/src/main/java/com/klaytn/caver/tx/Account.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Account.java
@@ -51,8 +51,8 @@ public class Account extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed. </p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
      */
     @Deprecated
@@ -63,8 +63,8 @@ public class Account extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/Account.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Account.java
@@ -51,8 +51,8 @@ public class Account extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
      */
     @Deprecated
@@ -63,8 +63,8 @@ public class Account extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/Account.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Account.java
@@ -52,8 +52,9 @@ public class Account extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed. </p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead.
+     *
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendUpdateTransaction(
@@ -64,8 +65,8 @@ public class Account extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendUpdateTransaction(

--- a/core/src/main/java/com/klaytn/caver/tx/Account.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Account.java
@@ -49,4 +49,31 @@ public class Account extends ManagedTransaction {
 
         return Account.create(caver, transactionManager);
     }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendUpdateTransaction(
+            Caver caver, KlayCredentials credentials, AccountUpdateTransaction transaction) {
+
+        return Account.sendUpdateTransaction(caver, credentials, transaction, null);
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendUpdateTransaction(AccountUpdateTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendUpdateTransaction(
+            Caver caver, KlayCredentials credentials, AccountUpdateTransaction transaction, ErrorHandler errorHandler) {
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
+                .setErrorHandler(errorHandler)
+                .build();
+
+        return new RemoteCall<>(() -> new Account(caver, transactionManager).send(transaction));
+    }
 }

--- a/core/src/main/java/com/klaytn/caver/tx/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Cancel.java
@@ -51,8 +51,8 @@ public class Cancel extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
      */
     @Deprecated
@@ -63,8 +63,8 @@ public class Cancel extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Cancel.java
@@ -51,8 +51,8 @@ public class Cancel extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
      */
     @Deprecated
@@ -63,8 +63,8 @@ public class Cancel extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Cancel.java
@@ -49,4 +49,33 @@ public class Cancel extends ManagedTransaction {
 
         return Cancel.create(caver, transactionManager);
     }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendCancelTransaction(
+            Caver caver, KlayCredentials credentials, CancelTransaction transaction) {
+
+        return Cancel.sendCancelTransaction(caver, credentials, transaction, null);
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendCancelTransaction(
+            Caver caver, KlayCredentials credentials, CancelTransaction transaction, ErrorHandler errorHandler) {
+
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
+                .setErrorHandler(errorHandler)
+                .build();
+
+        return new RemoteCall<>(() ->
+                new Cancel(caver, transactionManager).send(transaction));
+    }
 }

--- a/core/src/main/java/com/klaytn/caver/tx/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Cancel.java
@@ -52,8 +52,8 @@ public class Cancel extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendCancelTransaction(CancelTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendCancelTransaction(
@@ -64,8 +64,8 @@ public class Cancel extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendCancelTransaction(CancelTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendCancelTransaction(CancelTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendCancelTransaction(

--- a/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
+++ b/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
@@ -134,8 +134,8 @@ public class SmartContract extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendDeployTransaction(SmartContractDeployTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendDeployTransaction(
@@ -146,8 +146,8 @@ public class SmartContract extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendDeployTransaction(SmartContractDeployTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendDeployTransaction(
@@ -163,8 +163,8 @@ public class SmartContract extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(
@@ -175,8 +175,8 @@ public class SmartContract extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(

--- a/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
+++ b/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
@@ -133,8 +133,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
      */
     @Deprecated
@@ -145,8 +145,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
      */
     @Deprecated
@@ -162,8 +162,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
      */
     @Deprecated
@@ -174,8 +174,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
+++ b/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
@@ -133,8 +133,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
      */
     @Deprecated
@@ -145,8 +145,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
      */
     @Deprecated
@@ -162,8 +162,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
      */
     @Deprecated
@@ -174,8 +174,8 @@ public class SmartContract extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
+++ b/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
@@ -26,6 +26,7 @@ import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.Bytes;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
+import com.klaytn.caver.tx.manager.ErrorHandler;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import com.klaytn.caver.tx.model.SmartContractDeployTransaction;
 import com.klaytn.caver.tx.model.SmartContractExecutionTransaction;
@@ -130,6 +131,65 @@ public class SmartContract extends ManagedTransaction {
     public RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(SmartContractExecutionTransaction transaction) {
         return new RemoteCall<>(() -> send(transaction));
     }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendDeployTransaction(
+            Caver caver, KlayCredentials credentials, SmartContractDeployTransaction transaction) {
+
+        return SmartContract.sendDeployTransaction(caver, credentials, transaction, null);
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendDeployTransaction(SmartContractDeployTransaction)} ()} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendDeployTransaction(
+            Caver caver, KlayCredentials credentials, SmartContractDeployTransaction transaction, ErrorHandler errorHandler) {
+
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
+                .setErrorHandler(errorHandler)
+                .build();
+
+        return new RemoteCall<>(() ->
+                new SmartContract(caver, transactionManager).send(transaction));
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(
+            Caver caver, KlayCredentials credentials, SmartContractExecutionTransaction transaction) {
+
+        return SmartContract.sendExecutionTransaction(caver, credentials, transaction, null);
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendExecutionTransaction(SmartContractExecutionTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendExecutionTransaction(
+            Caver caver, KlayCredentials credentials, SmartContractExecutionTransaction transaction, ErrorHandler errorHandler) {
+
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
+                .setErrorHandler(errorHandler)
+                .build();
+
+        return new RemoteCall<>(() ->
+                new SmartContract(caver, transactionManager).send(transaction));
+    }
+
 
     public void setContractAddress(String contractAddress) {
         this.contractAddress = contractAddress;

--- a/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
@@ -23,6 +23,7 @@ package com.klaytn.caver.tx;
 import com.klaytn.caver.Caver;
 import com.klaytn.caver.crpyto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
+import com.klaytn.caver.tx.manager.ErrorHandler;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import com.klaytn.caver.utils.Convert;
 import com.klaytn.caver.tx.model.ValueTransferTransaction;
@@ -77,4 +78,62 @@ public class ValueTransfer extends ManagedTransaction {
 
         return ValueTransfer.create(caver, transactionManager);
     }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
+            Caver caver, KlayCredentials credentials, String toAddress, BigDecimal value, Convert.Unit unit, BigInteger gasLimit) {
+
+        return ValueTransfer.sendFunds(caver, credentials, toAddress, value, unit, gasLimit, null);
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
+            Caver caver, KlayCredentials credentials, String toAddress, BigDecimal value, Convert.Unit unit, BigInteger gasLimit, ErrorHandler errorHandler) {
+
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
+                .setErrorHandler(errorHandler)
+                .build();
+
+        return new RemoteCall<>(() ->
+                new ValueTransfer(caver, transactionManager).send(credentials.getAddress(), toAddress, value, unit, gasLimit));
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
+            Caver caver, KlayCredentials credentials, ValueTransferTransaction transaction) {
+
+        return ValueTransfer.sendFunds(caver, credentials, transaction, null);
+    }
+
+    /**
+     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
+     *              {will be removed in next version} <br/>
+     *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
+     */
+    @Deprecated
+    public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
+            Caver caver, KlayCredentials credentials, ValueTransferTransaction transaction, ErrorHandler errorHandler) {
+
+        TransactionManager transactionManager = new TransactionManager.Builder(caver, credentials)
+                .setErrorHandler(errorHandler)
+                .build();
+        return new RemoteCall<>(() ->
+                new ValueTransfer(caver, transactionManager).send(transaction));
+    }
+
 }

--- a/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
@@ -80,8 +80,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
      */
     @Deprecated
@@ -92,8 +92,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
      */
     @Deprecated
@@ -109,8 +109,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
      */
     @Deprecated
@@ -121,8 +121,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility. <br/>
-     *              {will be removed in next version} <br/>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
+     *              <p>{will be removed in next version}</p>
      *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
@@ -80,8 +80,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
      */
     @Deprecated
@@ -92,8 +92,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
      */
     @Deprecated
@@ -109,8 +109,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
      */
     @Deprecated
@@ -121,8 +121,8 @@ public class ValueTransfer extends ManagedTransaction {
     }
 
     /**
-     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods were removed for extensibility.</p>
-     *              <p>{will be removed in next version}</p>
+     * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
+     *              <p>This deprecated method can be used only for Baobab Testnet</p>
      *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
      */
     @Deprecated

--- a/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
@@ -81,8 +81,8 @@ public class ValueTransfer extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
@@ -93,8 +93,8 @@ public class ValueTransfer extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendFunds(String, String, BigDecimal, Convert.Unit, BigInteger)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
@@ -110,8 +110,8 @@ public class ValueTransfer extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendFunds(ValueTransferTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(
@@ -122,8 +122,8 @@ public class ValueTransfer extends ManagedTransaction {
 
     /**
      * @deprecated  <p>In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. The static methods will be removed.</p>
-     *              <p>This deprecated method can be used only for Baobab Testnet</p>
-     *              use {@link #sendFunds(ValueTransferTransaction)} instead like this:
+     *              <p>This deprecated method can be used only for Baobab Testnet.</p>
+     *              Use {@link #sendFunds(ValueTransferTransaction)} instead.
      */
     @Deprecated
     public static RemoteCall<KlayTransactionReceipt.TransactionReceipt> sendFunds(


### PR DESCRIPTION
## Proposed changes

- Added deprecated static methods at subclass of ManagedTransaction.
- In caver-java 1.0.0, we provided static methods to send transactions for `ValueTransfer`, `Account`, `Cancel`, and `SmartContract` classes. the static methods will removed for extensibility. 


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #5 

## Further comments

-