### PR TITLE
Feature/minor fixs 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ configure(subprojects.findAll { it.name != 'integration-test' }) {
                     passphrase = bintrayGpgPassphrase
                 }
                 mavenCentralSync {
-                    sync = true
+                    sync = false
                     user = ossrhUsername
                     password = ossrhPassword
                     close = '1'

--- a/codegen/src/main/java/com/klaytn/caver/codegen/SolidityFunctionWrapper.java
+++ b/codegen/src/main/java/com/klaytn/caver/codegen/SolidityFunctionWrapper.java
@@ -22,7 +22,7 @@ package com.klaytn.caver.codegen;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/codegen/src/test/java/com/klaytn/caver/codegen/SolidityFunctionWrapperGeneratorTest.java
+++ b/codegen/src/test/java/com/klaytn/caver/codegen/SolidityFunctionWrapperGeneratorTest.java
@@ -45,7 +45,7 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
     public void setUp() throws Exception {
         super.setUp();
 
-        URL url = SolidityFunctionWrapperGeneratorTest.class.getClass().getResource("/solidity");
+        URL url = SolidityFunctionWrapperGeneratorTest.class.getResource("/solidity");
         solidityBaseDir = url.getPath();
     }
 

--- a/core/src/main/java/com/klaytn/caver/crypto/KlayCredentials.java
+++ b/core/src/main/java/com/klaytn/caver/crypto/KlayCredentials.java
@@ -18,7 +18,7 @@
  * Modified and improved for the caver-java development.
  */
 
-package com.klaytn.caver.crpyto;
+package com.klaytn.caver.crypto;
 
 import org.web3j.crypto.ECKeyPair;
 import org.web3j.crypto.Keys;

--- a/core/src/main/java/com/klaytn/caver/crypto/KlaySignatureData.java
+++ b/core/src/main/java/com/klaytn/caver/crypto/KlaySignatureData.java
@@ -18,7 +18,7 @@
  * Modified and improved for the caver-java development.
  */
 
-package com.klaytn.caver.crpyto;
+package com.klaytn.caver.crypto;
 
 import org.web3j.rlp.RlpList;
 import org.web3j.rlp.RlpString;

--- a/core/src/main/java/com/klaytn/caver/fee/FeePayer.java
+++ b/core/src/main/java/com/klaytn/caver/fee/FeePayer.java
@@ -15,8 +15,8 @@
  */
 package com.klaytn.caver.fee;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlayCredentials;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlaySignatureDataUtils;
 import com.klaytn.caver.tx.model.KlayRawTransaction;
 import com.klaytn.caver.tx.type.AbstractTxType;

--- a/core/src/main/java/com/klaytn/caver/fee/FeePayerManager.java
+++ b/core/src/main/java/com/klaytn/caver/fee/FeePayerManager.java
@@ -22,11 +22,10 @@ package com.klaytn.caver.fee;
 
 import com.klaytn.caver.tx.exception.PlatformErrorException;
 import com.klaytn.caver.tx.manager.ErrorHandler;
-import com.klaytn.caver.tx.manager.NoOpTransactionReceiptProcessor;
 import com.klaytn.caver.tx.manager.PollingTransactionReceiptProcessor;
 import com.klaytn.caver.tx.manager.TransactionReceiptProcessor;
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.Bytes32;
 import com.klaytn.caver.methods.response.Callback;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;

--- a/core/src/main/java/com/klaytn/caver/methods/response/EmptyTransactionReceipt.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/EmptyTransactionReceipt.java
@@ -20,7 +20,7 @@
 
 package com.klaytn.caver.methods.response;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.tx.response.NoOpProcessor;
 import org.web3j.tx.response.QueuingTransactionReceiptProcessor;

--- a/core/src/main/java/com/klaytn/caver/methods/response/KlayTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/KlayTransaction.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import org.web3j.protocol.core.Response;
 import org.web3j.utils.Numeric;
 

--- a/core/src/main/java/com/klaytn/caver/methods/response/KlayTransactionReceipt.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/KlayTransactionReceipt.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import org.web3j.protocol.core.Response;
 import org.web3j.utils.Numeric;
 

--- a/core/src/main/java/com/klaytn/caver/tx/Account.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Account.java
@@ -21,7 +21,7 @@
 package com.klaytn.caver.tx;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.manager.ErrorHandler;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/core/src/main/java/com/klaytn/caver/tx/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/Cancel.java
@@ -21,7 +21,7 @@
 package com.klaytn.caver.tx;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.manager.ErrorHandler;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
+++ b/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
@@ -21,7 +21,7 @@
 package com.klaytn.caver.tx;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.Bytes;
 import com.klaytn.caver.methods.response.KlayLogs;

--- a/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/ValueTransfer.java
@@ -21,7 +21,7 @@
 package com.klaytn.caver.tx;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.manager.ErrorHandler;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/core/src/main/java/com/klaytn/caver/tx/manager/FastGetNonceProcessor.java
+++ b/core/src/main/java/com/klaytn/caver/tx/manager/FastGetNonceProcessor.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.tx.manager;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 
 import java.io.IOException;
 import java.math.BigInteger;

--- a/core/src/main/java/com/klaytn/caver/tx/manager/GetNonceProcessor.java
+++ b/core/src/main/java/com/klaytn/caver/tx/manager/GetNonceProcessor.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.tx.manager;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.Quantity;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 

--- a/core/src/main/java/com/klaytn/caver/tx/manager/TransactionManager.java
+++ b/core/src/main/java/com/klaytn/caver/tx/manager/TransactionManager.java
@@ -21,7 +21,7 @@
 package com.klaytn.caver.tx.manager;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.Bytes32;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.model.TransactionTransformer;

--- a/core/src/main/java/com/klaytn/caver/tx/model/KlayRawTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/model/KlayRawTransaction.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.model;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import org.web3j.utils.Numeric;
 
 public class KlayRawTransaction {

--- a/core/src/main/java/com/klaytn/caver/tx/type/AbstractTxType.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/AbstractTxType.java
@@ -16,8 +16,8 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlayCredentials;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.tx.exception.EmptyNonceException;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.KlaySignatureDataUtils;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxType.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxType.java
@@ -16,8 +16,8 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlayCredentials;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.tx.model.KlayRawTransaction;
 import org.web3j.rlp.RlpType;
 

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeChainDataAnchoringTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeChainDataAnchoringTransaction.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedAccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedAccountUpdate.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.tx.account.AccountKey;
 import com.klaytn.caver.tx.account.AccountKeyDecoder;
 import com.klaytn.caver.utils.KlayTransactionUtils;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedAccountUpdateWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedAccountUpdateWithRatio.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.tx.account.AccountKey;
 import com.klaytn.caver.tx.account.AccountKeyDecoder;
 import com.klaytn.caver.utils.KlayTransactionUtils;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedCancel.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedCancel.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedCancelWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedCancelWithRatio.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractDeploy.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractDeployWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractDeployWithRatio.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractExecution.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractExecutionWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedSmartContractExecutionWithRatio.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransfer.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransferMemo.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransferMemoWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransferMemoWithRatio.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransferWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeFeeDelegatedValueTransferWithRatio.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlayTransactionUtils;
 import org.web3j.rlp.RlpDecoder;
 import org.web3j.rlp.RlpList;

--- a/core/src/main/java/com/klaytn/caver/tx/type/TxTypeLegacyTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/type/TxTypeLegacyTransaction.java
@@ -16,8 +16,8 @@
 
 package com.klaytn.caver.tx.type;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlayCredentials;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.utils.KlaySignatureDataUtils;
 import com.klaytn.caver.tx.model.KlayRawTransaction;
 import org.web3j.crypto.Sign;

--- a/core/src/main/java/com/klaytn/caver/utils/KlaySignatureDataUtils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/KlaySignatureDataUtils.java
@@ -20,7 +20,7 @@
 
 package com.klaytn.caver.utils;
 
-import com.klaytn.caver.crpyto.KlaySignatureData;
+import com.klaytn.caver.crypto.KlaySignatureData;
 import org.web3j.crypto.Sign;
 
 import java.math.BigInteger;

--- a/core/src/main/java/com/klaytn/caver/wallet/KlayWalletUtils.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/KlayWalletUtils.java
@@ -23,7 +23,7 @@ package com.klaytn.caver.wallet;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import org.web3j.crypto.*;
 import org.web3j.utils.Numeric;
 

--- a/core/src/main/java/com/klaytn/caver/wallet/WalletManager.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/WalletManager.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.wallet;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.wallet.exception.CredentialNotFoundException;
 
 import java.util.HashMap;

--- a/core/src/test/java/com/klaytn/caver/base/Accounts.java
+++ b/core/src/test/java/com/klaytn/caver/base/Accounts.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.base;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import com.klaytn.caver.tx.model.ValueTransferTransaction;
 import com.klaytn.caver.utils.Convert;

--- a/core/src/test/java/com/klaytn/caver/base/LocalValues.java
+++ b/core/src/test/java/com/klaytn/caver/base/LocalValues.java
@@ -1,6 +1,6 @@
 package com.klaytn.caver.base;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 
 public class LocalValues {
     public static final KlayCredentials KLAY_PROVIDER = KlayCredentials.create(

--- a/core/src/test/java/com/klaytn/caver/feature/AccountKeyTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/AccountKeyTest.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.feature;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.account.*;
 import org.junit.Test;
 import org.web3j.utils.Numeric;

--- a/core/src/test/java/com/klaytn/caver/feature/KlayWalletUtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/KlayWalletUtilsTest.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.feature;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.wallet.KlayWalletUtils;
 import org.junit.Test;
 import org.web3j.utils.Numeric;

--- a/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/ManagedTransactionTest.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.feature;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.Account;
 import com.klaytn.caver.tx.SmartContract;

--- a/core/src/test/java/com/klaytn/caver/feature/RpcTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/RpcTest.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.feature;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.request.KlayFilter;
 import com.klaytn.caver.methods.request.KlayLogFilter;

--- a/core/src/test/java/com/klaytn/caver/feature/TransactionManagerTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/TransactionManagerTest.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.feature;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.ValueTransfer;

--- a/core/src/test/java/com/klaytn/caver/feature/TransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/TransactionTest.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.feature;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.fee.FeePayer;
 import com.klaytn.caver.tx.account.AccountKey;
 import com.klaytn.caver.tx.account.AccountKeyPublic;

--- a/core/src/test/java/com/klaytn/caver/feature/TransactionTransformTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/TransactionTransformTest.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.feature;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.account.AccountKeyPublic;
 import com.klaytn.caver.tx.model.*;
 import com.klaytn.caver.tx.type.TxType;

--- a/core/src/test/java/com/klaytn/caver/scenario/AccountKeyIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/AccountKeyIT.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.scenario;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.Account;
 import com.klaytn.caver.tx.ValueTransfer;

--- a/core/src/test/java/com/klaytn/caver/scenario/FeePayerManagerIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/FeePayerManagerIT.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.scenario;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.fee.FeePayerManager;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.ValueTransfer;

--- a/core/src/test/java/com/klaytn/caver/scenario/Scenario.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/Scenario.java
@@ -21,7 +21,7 @@
 package com.klaytn.caver.scenario;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.fee.FeePayerManager;
 import com.klaytn.caver.methods.response.Bytes32;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;

--- a/core/src/test/java/com/klaytn/caver/scenario/TransactionIT.java
+++ b/core/src/test/java/com/klaytn/caver/scenario/TransactionIT.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.scenario;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/AddressImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/AddressImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/CappedCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/CappedCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/CappedCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/CappedCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/CapperRole.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/CapperRole.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/CapperRoleMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/CapperRoleMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ConditionalEscrow.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ConditionalEscrow.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ConditionalEscrowMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ConditionalEscrowMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/CountersImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/CountersImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/Crowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/Crowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/CrowdsaleMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/CrowdsaleMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ECDSAMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ECDSAMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC165.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC165.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC165CheckerMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC165CheckerMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC165InterfacesSupported.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC165InterfacesSupported.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC165Mock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC165Mock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC1820Implementer.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC1820Implementer.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC1820ImplementerMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC1820ImplementerMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Burnable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Burnable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20BurnableMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20BurnableMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Capped.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Capped.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Detailed.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Detailed.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20DetailedMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20DetailedMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Metadata.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Metadata.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20MetadataMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20MetadataMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Mintable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Mintable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20MintableMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20MintableMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Mock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Mock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Pausable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20Pausable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC20PausableMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC20PausableMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Burnable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Burnable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Enumerable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Enumerable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Full.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Full.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721FullMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721FullMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Holder.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Holder.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Metadata.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Metadata.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721MetadataMintable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721MetadataMintable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Mintable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Mintable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721MintableBurnableImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721MintableBurnableImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Mock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Mock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Pausable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721Pausable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721PausableMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721PausableMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC721ReceiverMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC721ReceiverMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC777.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC777.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC777Mock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC777Mock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ERC777SenderRecipientMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ERC777SenderRecipientMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/Escrow.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/Escrow.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/FinalizableCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/FinalizableCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/FinalizableCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/FinalizableCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC165.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC165.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC1820Implementer.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC1820Implementer.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC1820Registry.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC1820Registry.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC20.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC20.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC721.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC721.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Enumerable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Enumerable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Full.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Full.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Metadata.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Metadata.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Receiver.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC721Receiver.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC777.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC777.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC777Recipient.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC777Recipient.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IERC777Sender.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IERC777Sender.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IncreasingPriceCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IncreasingPriceCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IncreasingPriceCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IncreasingPriceCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IndividuallyCappedCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IndividuallyCappedCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/IndividuallyCappedCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/IndividuallyCappedCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/MathMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/MathMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.math.BigInteger;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/MerkleProofWrapper.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/MerkleProofWrapper.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/MintedCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/MintedCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/MintedCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/MintedCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/MinterRole.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/MinterRole.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/MinterRoleMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/MinterRoleMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/Ownable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/Ownable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/OwnableInterfaceId.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/OwnableInterfaceId.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.util.Arrays;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/OwnableMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/OwnableMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/Pausable.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/Pausable.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PausableCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PausableCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PausableCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PausableCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PausableMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PausableMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PauserRole.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PauserRole.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PauserRoleMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PauserRoleMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PaymentSplitter.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PaymentSplitter.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PostDeliveryCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PostDeliveryCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PostDeliveryCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PostDeliveryCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PullPayment.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PullPayment.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/PullPaymentMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/PullPaymentMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ReentrancyAttack.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ReentrancyAttack.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ReentrancyGuard.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ReentrancyGuard.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import org.web3j.protocol.core.RemoteCall;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/ReentrancyMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/ReentrancyMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/RefundEscrow.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/RefundEscrow.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/RefundableCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/RefundableCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/RefundableCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/RefundableCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/RefundablePostDeliveryCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/RefundablePostDeliveryCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/RefundablePostDeliveryCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/RefundablePostDeliveryCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/RolesMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/RolesMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SafeMathMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SafeMathMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.math.BigInteger;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SampleCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SampleCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/Secondary.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/Secondary.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SecondaryMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SecondaryMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SignatureBouncer.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SignatureBouncer.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SignatureBouncerMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SignatureBouncerMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SignedSafeMathMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SignedSafeMathMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;
 import java.math.BigInteger;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SignerRole.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SignerRole.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SignerRoleMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SignerRoleMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/SimpleToken.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/SimpleToken.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/TimedCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/TimedCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/TimedCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/TimedCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/TokenTimelock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/TokenTimelock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;
 import com.klaytn.caver.tx.manager.TransactionManager;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/TokenVesting.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/TokenVesting.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistAdminRole.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistAdminRole.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistAdminRoleMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistAdminRoleMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistCrowdsale.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistCrowdsale.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistCrowdsaleImpl.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistCrowdsaleImpl.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistedRole.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistedRole.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistedRoleMock.java
+++ b/integration-test/src/test/java/com/klaytn/caver/generated/WhitelistedRoleMock.java
@@ -1,7 +1,7 @@
 package com.klaytn.caver.generated;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.tx.SmartContract;

--- a/integration-test/src/test/java/com/klaytn/caver/model/ContractHelper.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/ContractHelper.java
@@ -18,7 +18,7 @@ package com.klaytn.caver.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.model.dto.Env;
 import com.klaytn.caver.model.dto.Transaction;
 import com.klaytn.caver.tx.gas.DefaultGasProvider;

--- a/integration-test/src/test/java/com/klaytn/caver/model/StringReplacer.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/StringReplacer.java
@@ -19,7 +19,7 @@ package com.klaytn.caver.model;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayBlock;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.model.dto.Env;

--- a/integration-test/src/test/java/com/klaytn/caver/model/TestGenerator.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/TestGenerator.java
@@ -18,7 +18,7 @@ package com.klaytn.caver.model;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.model.dto.*;
 import com.klaytn.caver.model.executor.ApiExecutor;
 import com.klaytn.caver.model.executor.ContractExecutor;

--- a/integration-test/src/test/java/com/klaytn/caver/model/VariableStorage.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/VariableStorage.java
@@ -16,7 +16,7 @@
 
 package com.klaytn.caver.model;
 
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import org.web3j.crypto.Keys;
 
 import java.util.*;

--- a/integration-test/src/test/java/com/klaytn/caver/model/dto/Transaction.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/dto/Transaction.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.model.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayAccountKey;
 import com.klaytn.caver.tx.account.AccountKey;
 import com.klaytn.caver.utils.Convert;

--- a/integration-test/src/test/java/com/klaytn/caver/model/executor/ContractExecutor.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/executor/ContractExecutor.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.model.executor;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.model.ContractHelper;
 import com.klaytn.caver.model.VariableStorage;
 import com.klaytn.caver.model.dto.Contract;

--- a/integration-test/src/test/java/com/klaytn/caver/model/executor/TransactionExecutor.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/executor/TransactionExecutor.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.model.executor;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.fee.FeePayerManager;
 import com.klaytn.caver.methods.response.Bytes32;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;

--- a/integration-test/src/test/java/com/klaytn/caver/model/validator/ContractValidator.java
+++ b/integration-test/src/test/java/com/klaytn/caver/model/validator/ContractValidator.java
@@ -17,7 +17,7 @@
 package com.klaytn.caver.model.validator;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.klaytn.caver.crpyto.KlayCredentials;
+import com.klaytn.caver.crypto.KlayCredentials;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.model.ContractHelper;
 import com.klaytn.caver.model.dto.Expected;


### PR DESCRIPTION
## Proposed changes

- changed maven central sync setting from `true` to `false`
  - Before this change, Bintray(Jcenter) sync with maven central automatically. But it's can be problematic when some module deployed successfully and the other module has a failure. Only success modules could be synced with maven central
- change typo in crypto package name
- remove redundant code in a test class
  - This redundant code can be a problem in java12

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

#13 

## Further comments

Package name change can cause considerable effects to some caver-java users. It need to be dealt carefully before merge.