### PR TITLE
bug decoding receipt public key

### DIFF
--- a/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
+++ b/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
@@ -92,7 +92,7 @@ public class AccountKeyPublic implements AccountKey {
     }
 
     public String getX() {
-        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.x),64);
+        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.x), 64);
     }
 
     public String getY() {

--- a/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
+++ b/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
@@ -92,7 +92,7 @@ public class AccountKeyPublic implements AccountKey {
     }
 
     public String getX() {
-        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.x),64);;
+        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.x),64);
     }
 
     public String getY() {

--- a/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
+++ b/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
@@ -92,11 +92,11 @@ public class AccountKeyPublic implements AccountKey {
     }
 
     public String getX() {
-        return x;
+        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.x),64);;
     }
 
     public String getY() {
-        return y;
+        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.y),64);
     }
 
     @Override

--- a/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
+++ b/core/src/main/java/com/klaytn/caver/tx/account/AccountKeyPublic.java
@@ -96,7 +96,7 @@ public class AccountKeyPublic implements AccountKey {
     }
 
     public String getY() {
-        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.y),64);
+        return Numeric.toHexStringWithPrefixZeroPadded(Numeric.toBigInt(this.y), 64);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

- When the `account key` is received from the Klaytn network from the receipt, it is decoded and stored as `AccountKeyPublic`. The leading zero is removed. AccountKeyPublic needs to hold 64 characters, so it fills in and returns the key when it is read.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
