### PR TITLE
[circleci] Add tagger verify job on major deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ machine_ubuntu: &machine_ubuntu
 android_machine_ubuntu: &android_machine_ubuntu
   working_directory: ~/circleci-caver-java-android
   machine:
-    image: ubuntu-1604:201903-01    
+    image: ubuntu-1604:201903-01
 
 pull_klaytn_image: &pull_klaytn_image
   run:
@@ -24,7 +24,7 @@ pull_klaytn_image: &pull_klaytn_image
 
 start_test_newwork: &start_test_newwork
   run:
-    name: "Start test network"  
+    name: "Start test network"
     working_directory: .circleci/images
     command: docker-compose up -d
 
@@ -107,6 +107,21 @@ jobs:
               exit 1
             fi
 
+  tagger_verify:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: "Verify tag and file verison match"
+          command: |
+            TAGGER=$(git for-each-ref --format='%(tagger)' refs/tags/$CIRCLE_TAG | sed 's/ .*//')
+            if [ $TAGGER == 'circleci-klaytn' ]; then
+              echo "Pass! Tagger is circleci-klaytn"
+            else
+              echo "only circleci-klaytn can tagging major version"
+              exit 1
+            fi
+
   release_PR:
     <<: *defaults
     steps:
@@ -135,13 +150,7 @@ jobs:
                 echo "PR already exist"
               else
                 echo "hub pull-request -m "[Master] release/$CIRCLE_TAG QA Signoff" -b $CIRCLE_PROJECT_USERNAME:master -h $CIRCLE_PROJECT_USERNAME:${CIRCLE_TAG%-*}"
-                hub pull-request -b $CIRCLE_PROJECT_USERNAME:master -h $CIRCLE_PROJECT_USERNAME:release/${CIRCLE_TAG%-*} -r $GITHUB_reviewer -l circleci -F- <<EOF
-                [Master] release/${CIRCLE_TAG%-*} QA Sign-off
-
-                This PR is automatically created by CI to release a new official version of $CIRCLE_PROJECT_REPONAME.
-
-                When this PR is approved by QA team, a new version will be released.
-              EOF
+                echo -e "[Master] release/${CIRCLE_TAG%-*} QA Sign-off\n\nThis PR is automatically created by CI to release a new official version of $CIRCLE_PROJECT_REPONAME.\n\nWhen this PR is approved by QA team, a new version will be released." | hub pull-request -b $CIRCLE_PROJECT_USERNAME:master -h $CIRCLE_PROJECT_USERNAME:release/${CIRCLE_TAG%-*} -r $GITHUB_reviewer -l circleci -F-
               fi
 
   major_tagging:
@@ -153,9 +162,10 @@ jobs:
           name: "Generate tag"
           command: |
               current_version=$(.circleci/version.sh)
-
               echo "git tag v$current_version"
-              git tag v$current_version
+              git config --global user.email "team.devops@groundx.xyz"
+              git config --global user.name "circleci-klaytn"
+              git tag -a v$current_version -m "$CIRCLE_STAGE"
               git push origin v$current_version
       - run:
           name: "Delete release branch"
@@ -254,7 +264,14 @@ workflows:
     - tag_verify:
         filters:
           tags:
-            only: /^v[0-9]+\.[0-9]+\.[0-9]+-rc.*/
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+          branches:
+            ignore: /.*/
+
+    - tagger_verify:
+        filters:
+          tags:
+            only: /^v[0-9]+\.[0-9]+\.[0-9]+/
           branches:
             ignore: /.*/
 
@@ -271,9 +288,12 @@ workflows:
     - major_tagging:
         filters:
           branches:
-            only: master       
+            only: master
           
     - android_publish:
+        requires:
+          - tag_verify
+          - tagger_verify
         # requires:
         #   - android_build
         filters:
@@ -292,4 +312,4 @@ workflows:
             #only: /^v[0-9]+\.[0-9]+\.[0-9]+/
             only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
           branches:
-            ignore: /.*/               
+            ignore: /.*/


### PR DESCRIPTION
## Proposed changes

- Add tagger verify job on major publish for prevent human error

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
