### PR TITLE
add exporting klyatn wallet key exception

### DIFF
--- a/core/src/main/java/com/klaytn/caver/crypto/KlayCredentials.java
+++ b/core/src/main/java/com/klaytn/caver/crypto/KlayCredentials.java
@@ -291,9 +291,17 @@ public class KlayCredentials {
     }
 
     public String getKlaytnWalletKey() {
+        if (!canExportKlaytnWalletKey()) {
+            throw new RuntimeException("The account cannot be exported in KlaytnWalletKey format. Use the WalletFile.createFull(String password, KlayCredentials klayCredentials) or WalletFile.createStandard(String password, KlayCredentials klayCredentials)");
+        }
+
         return Numeric.toHexStringWithPrefixZeroPadded(getEcKeyPair().getPrivateKey(), 64)
                 + CHECKSUM
                 + getAddress();
+    }
+
+    private boolean canExportKlaytnWalletKey() {
+        return ecKeyPairForTransactionList.size() == 1 && ecKeyPairForUpdateList.size() == 0 && ecKeyPairForFeeFeePayerList.size() == 0;
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

- caver-java provides the klaytn wallet key extraction function. The klaytn wallet key is a string consisting of a combination of a private key and an address. The format of the klaytn wallet key for roleBased account and multiSig has not been determined so that exeption occurs in this situation.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
