### PR TITLE
fix validate keystore version3 bug

### DIFF
--- a/core/src/main/java/com/klaytn/caver/wallet/Wallet.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/Wallet.java
@@ -349,8 +349,10 @@ public class Wallet {
         if (walletFile.getVersion() == VERSION_3) {
             WalletFile.Crypto crypto = walletFile.getCrypto();
             validateCrypto(crypto);
+            return;
         }
 
+        // Validate current version
         List keyRing = walletFile.getKeyring();
         if (keyRing.get(0) instanceof WalletFile.Crypto) {
             for (WalletFile.Crypto crypto : (List<WalletFile.Crypto>)keyRing) {


### PR DESCRIPTION
## Proposed changes

- When validating keysotore version3, it also validates version4 and causes a problem.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
