### PR TITLE
Custom gas price

### DIFF
--- a/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
+++ b/core/src/main/java/com/klaytn/caver/tx/SmartContract.java
@@ -374,6 +374,7 @@ public class SmartContract extends ManagedTransaction {
                     transactionManager.getDefaultAddress(),
                     pebValue,
                     Numeric.hexStringToByteArray(data),
+                    gasProvider.getGasPrice(funcName),
                     gasProvider.getGasLimit(funcName),
                     CodeFormat.EVM
             );
@@ -383,6 +384,7 @@ public class SmartContract extends ManagedTransaction {
                     contractAddress,
                     pebValue,
                     Numeric.hexStringToByteArray(data),
+                    gasProvider.getGasPrice(funcName),
                     gasProvider.getGasLimit(funcName)
             );
         }

--- a/core/src/main/java/com/klaytn/caver/tx/gas/DefaultGasProvider.java
+++ b/core/src/main/java/com/klaytn/caver/tx/gas/DefaultGasProvider.java
@@ -20,6 +20,7 @@
 
 package com.klaytn.caver.tx.gas;
 
+import com.klaytn.caver.Caver;
 import com.klaytn.caver.tx.ManagedTransaction;
 import com.klaytn.caver.tx.SmartContract;
 import org.web3j.tx.gas.StaticGasProvider;
@@ -32,5 +33,9 @@ public class DefaultGasProvider extends StaticGasProvider {
 
     public DefaultGasProvider() {
         super(GAS_PRICE, GAS_LIMIT);
+    }
+
+    public DefaultGasProvider(Caver caver) throws Exception{
+        super(caver.klay().getGasPrice().send().getValue(), GAS_LIMIT);
     }
 }

--- a/core/src/main/java/com/klaytn/caver/tx/model/AccountUpdateTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/model/AccountUpdateTransaction.java
@@ -34,8 +34,17 @@ public class AccountUpdateTransaction extends TransactionTransformer<AccountUpda
         this.accountKey = accountKey;
     }
 
+    private AccountUpdateTransaction(String from, AccountKey accountKey, BigInteger gasPrice, BigInteger gasLimit) {
+        super(from, gasPrice, gasLimit);
+        this.accountKey = accountKey;
+    }
+
     public static AccountUpdateTransaction create(String from, AccountKey accountKey, BigInteger gasLimit) {
         return new AccountUpdateTransaction(from, accountKey, gasLimit);
+    }
+
+    public static AccountUpdateTransaction create(String from, AccountKey accountKey, BigInteger gasPrice, BigInteger gasLimit) {
+        return new AccountUpdateTransaction(from, accountKey, gasPrice, gasLimit);
     }
 
     public AccountUpdateTransaction feeRatio(BigInteger feeRatio) {

--- a/core/src/main/java/com/klaytn/caver/tx/model/CancelTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/model/CancelTransaction.java
@@ -30,9 +30,16 @@ public class CancelTransaction extends TransactionTransformer<CancelTransaction>
     private CancelTransaction(String from, BigInteger gasLimit) {
         super(from, gasLimit);
     }
+    private CancelTransaction(String from, BigInteger gasPrice, BigInteger gasLimit) {
+        super(from, gasPrice, gasLimit);
+    }
 
     public static CancelTransaction create(String from, BigInteger gasLimit) {
         return new CancelTransaction(from, gasLimit);
+    }
+
+    public static CancelTransaction create(String from, BigInteger gasPrice, BigInteger gasLimit) {
+        return new CancelTransaction(from, gasPrice, gasLimit);
     }
 
     public CancelTransaction feeRatio(BigInteger feeRatio) {

--- a/core/src/main/java/com/klaytn/caver/tx/model/SmartContractDeployTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/model/SmartContractDeployTransaction.java
@@ -37,9 +37,21 @@ public class SmartContractDeployTransaction extends TransactionTransformer<Smart
         this.codeFormat = codeFormat;
     }
 
+    private SmartContractDeployTransaction(String from, BigInteger amount, byte[] payload, BigInteger gasPrice, BigInteger gasLimit, BigInteger codeFormat) {
+        super(from, gasPrice, gasLimit);
+        this.amount = amount;
+        this.payload = payload;
+        this.codeFormat = codeFormat;
+    }
+
     public static SmartContractDeployTransaction create(
             String from, BigInteger amount, byte[] payload, BigInteger gasLimit, BigInteger codeFormat) {
         return new SmartContractDeployTransaction(from, amount, payload, gasLimit, codeFormat);
+    }
+
+    public static SmartContractDeployTransaction create(
+            String from, BigInteger amount, byte[] payload, BigInteger gasPrice, BigInteger gasLimit, BigInteger codeFormat) {
+        return new SmartContractDeployTransaction(from, amount, payload, gasPrice, gasLimit, codeFormat);
     }
 
     public SmartContractDeployTransaction feeRatio(BigInteger feeRatio) {

--- a/core/src/main/java/com/klaytn/caver/tx/model/SmartContractExecutionTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/model/SmartContractExecutionTransaction.java
@@ -38,9 +38,22 @@ public class SmartContractExecutionTransaction extends TransactionTransformer<Sm
         this.payload = payload;
     }
 
+    private SmartContractExecutionTransaction(String from, String recipient, BigInteger amount,
+                                              byte[] payload, BigInteger gasPrice, BigInteger gasLimit) {
+        super(from, gasPrice, gasLimit);
+        this.recipient = recipient;
+        this.amount = amount;
+        this.payload = payload;
+    }
+
     public static SmartContractExecutionTransaction create(String from, String recipient, BigInteger amount,
                                                            byte[] payload, BigInteger gasLimit) {
         return new SmartContractExecutionTransaction(from, recipient, amount, payload, gasLimit);
+    }
+
+    public static SmartContractExecutionTransaction create(String from, String recipient, BigInteger amount,
+                                                           byte[] payload, BigInteger gasPrice, BigInteger gasLimit) {
+        return new SmartContractExecutionTransaction(from, recipient, amount, payload, gasPrice, gasLimit);
     }
 
     public SmartContractExecutionTransaction feeRatio(BigInteger feeRatio) {

--- a/core/src/main/java/com/klaytn/caver/tx/model/TransactionTransformer.java
+++ b/core/src/main/java/com/klaytn/caver/tx/model/TransactionTransformer.java
@@ -60,6 +60,12 @@ public abstract class TransactionTransformer<T extends TransactionTransformer> {
         this.gasLimit = gasLimit;
     }
 
+    public TransactionTransformer(String from, BigInteger gasPrice, BigInteger gasLimit) {
+        this.from = from;
+        this.gasLimit = gasLimit;
+        this.gasPrice = gasPrice;
+    }
+
     public BigInteger getNonce() {
         return nonce;
     }

--- a/core/src/main/java/com/klaytn/caver/tx/model/ValueTransferTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/tx/model/ValueTransferTransaction.java
@@ -33,8 +33,18 @@ public class ValueTransferTransaction extends TransactionTransformer<ValueTransf
         this.amount = amount;
     }
 
+    private ValueTransferTransaction(String from, String to, BigInteger amount, BigInteger gasPrice, BigInteger gasLimit) {
+        super(from, gasPrice, gasLimit);
+        this.to = to;
+        this.amount = amount;
+    }
+
     public static ValueTransferTransaction create(String from, String to, BigInteger amount, BigInteger gasLimit) {
         return new ValueTransferTransaction(from, to, amount, gasLimit);
+    }
+
+    public static ValueTransferTransaction create(String from, String to, BigInteger amount, BigInteger gasPrice, BigInteger gasLimit) {
+        return new ValueTransferTransaction(from, to, amount, gasPrice, gasLimit);
     }
 
     public ValueTransferTransaction memo(String memo) {

--- a/core/src/test/java/com/klaytn/caver/feature/CustomGasTest.java
+++ b/core/src/test/java/com/klaytn/caver/feature/CustomGasTest.java
@@ -1,0 +1,250 @@
+package com.klaytn.caver.feature;
+
+import com.klaytn.caver.Caver;
+import com.klaytn.caver.crypto.KlayCredentials;
+import com.klaytn.caver.fee.FeePayerManager;
+import com.klaytn.caver.tx.account.AccountKeyPublic;
+import com.klaytn.caver.tx.manager.TransactionManager;
+import com.klaytn.caver.tx.model.*;
+import com.klaytn.caver.tx.type.AbstractTxType;
+import com.klaytn.caver.utils.CodeFormat;
+import com.klaytn.caver.utils.TransactionDecoder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.web3j.crypto.Keys;
+import com.klaytn.caver.utils.ChainId;
+import org.web3j.utils.Numeric;
+import static junit.framework.TestCase.assertEquals;
+
+import java.math.BigInteger;
+
+public class CustomGasTest {
+    private static final BigInteger GAS_PRICE = BigInteger.valueOf(10L);
+    private static final BigInteger GAS_LIMIT = BigInteger.valueOf(3000000L);
+
+    private static int CHAIN_ID;
+    private static Caver caver;
+
+    private static KlayCredentials sender;
+    private static KlayCredentials feePayer;
+    private static KlayCredentials to;
+
+    private static BigInteger nonce;
+    private static BigInteger value;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        CHAIN_ID = ChainId.BAOBAB_TESTNET;
+        caver = Caver.build("https://api.baobab.klaytn.net:8651/");
+
+        sender = KlayCredentials.create(Keys.createEcKeyPair());
+        feePayer = KlayCredentials.create(Keys.createEcKeyPair());
+        to = KlayCredentials.create(Keys.createEcKeyPair());
+
+        nonce = BigInteger.ZERO;
+        value = BigInteger.ZERO;
+    }
+
+    @Test
+    public void testCustomGasPriceWithValueTransfer() throws Exception {
+        ValueTransferTransaction tx = ValueTransferTransaction.create(
+                sender.getAddress(),
+                to.getAddress(),
+                value,
+                GAS_PRICE,
+                GAS_LIMIT
+        );
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        TransactionManager tm = new TransactionManager.Builder(caver, sender).build();
+        KlayRawTransaction rawTransaction = tm.sign(tx);
+        AbstractTxType decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeDelegate();
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        FeePayerManager fm = new FeePayerManager.Builder(caver, feePayer).build();
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeRatio(BigInteger.valueOf(50));
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+    }
+
+    @Test
+    public void testCustomGasPriceWithValueTransferMemo() throws Exception {
+        ValueTransferTransaction tx = ValueTransferTransaction.create(
+                sender.getAddress(),
+                to.getAddress(),
+                value,
+                GAS_PRICE,
+                GAS_LIMIT
+        ).memo("test string");
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        TransactionManager tm = new TransactionManager.Builder(caver, sender).build();
+        KlayRawTransaction rawTransaction = tm.sign(tx);
+        AbstractTxType decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeDelegate();
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        FeePayerManager fm = new FeePayerManager.Builder(caver, feePayer).build();
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeRatio(BigInteger.valueOf(50));
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+    }
+
+    @Test
+    public void testCustomGasPriceWithAccountUpdate() throws Exception {
+        AccountUpdateTransaction tx = AccountUpdateTransaction.create(
+                sender.getAddress(),
+                AccountKeyPublic.create(Keys.createEcKeyPair().getPublicKey()),
+                GAS_PRICE,
+                GAS_LIMIT
+        );
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        TransactionManager tm = new TransactionManager.Builder(caver, sender).build();
+        KlayRawTransaction rawTransaction = tm.sign(tx);
+        AbstractTxType decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeDelegate();
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        FeePayerManager fm = new FeePayerManager.Builder(caver, feePayer).build();
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeRatio(BigInteger.valueOf(50));
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+    }
+
+    @Test
+    public void testCustomGasPriceWithSmartContractDeploy() throws Exception {
+        SmartContractDeployTransaction tx = SmartContractDeployTransaction.create(
+                sender.getAddress(),
+                value,
+                Numeric.hexStringToByteArray("0x608060405234801561001057600080fd5b506101de806100206000396000f3006080604052600436106100615763ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416631a39d8ef81146100805780636353586b146100a757806370a08231146100ca578063fd6b7ef8146100f8575b3360009081526001602052604081208054349081019091558154019055005b34801561008c57600080fd5b5061009561010d565b60408051918252519081900360200190f35b6100c873ffffffffffffffffffffffffffffffffffffffff60043516610113565b005b3480156100d657600080fd5b5061009573ffffffffffffffffffffffffffffffffffffffff60043516610147565b34801561010457600080fd5b506100c8610159565b60005481565b73ffffffffffffffffffffffffffffffffffffffff1660009081526001602052604081208054349081019091558154019055565b60016020526000908152604090205481565b336000908152600160205260408120805490829055908111156101af57604051339082156108fc029083906000818181858888f193505050501561019c576101af565b3360009081526001602052604090208190555b505600a165627a7a72305820627ca46bb09478a015762806cc00c431230501118c7c26c30ac58c4e09e51c4f0029"),
+                GAS_PRICE,
+                GAS_LIMIT,
+                CodeFormat.EVM
+        );
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        TransactionManager tm = new TransactionManager.Builder(caver, sender).build();
+        KlayRawTransaction rawTransaction = tm.sign(tx);
+        AbstractTxType decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeDelegate();
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        FeePayerManager fm = new FeePayerManager.Builder(caver, feePayer).build();
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeRatio(BigInteger.valueOf(50));
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+    }
+
+    @Test
+    public void testCustomGasPriceWithSmartContractExecution() throws Exception {
+        SmartContractExecutionTransaction tx = SmartContractExecutionTransaction.create(
+                sender.getAddress(),
+                to.getAddress(),
+                value,
+                Numeric.hexStringToByteArray("0xd14e62b8000000000000000000000000000000000000000000000000dc67327b51f7c636"),
+                GAS_PRICE,
+                GAS_LIMIT
+        );
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        TransactionManager tm = new TransactionManager.Builder(caver, sender).build();
+        KlayRawTransaction rawTransaction = tm.sign(tx);
+        AbstractTxType decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeDelegate();
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        FeePayerManager fm = new FeePayerManager.Builder(caver, feePayer).build();
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeRatio(BigInteger.valueOf(50));
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+    }
+
+    @Test
+    public void testCustomGasPriceWithCancel() throws Exception {
+        CancelTransaction tx = CancelTransaction.create(
+                sender.getAddress(),
+                GAS_PRICE,
+                GAS_LIMIT
+        );
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        TransactionManager tm = new TransactionManager.Builder(caver, sender).build();
+        KlayRawTransaction rawTransaction = tm.sign(tx);
+        AbstractTxType decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeDelegate();
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        FeePayerManager fm = new FeePayerManager.Builder(caver, feePayer).build();
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+
+        tx.feeRatio(BigInteger.valueOf(50));
+        assertEquals(tx.getGasPrice(), GAS_PRICE);
+
+        rawTransaction = tm.sign(tx);
+        rawTransaction = fm.sign(rawTransaction.getValueAsString());
+        decoded = TransactionDecoder.decode(rawTransaction.getValueAsString());
+        assertEquals(decoded.getGasPrice(), GAS_PRICE);
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR introduces fixes for setting custom gas unit price.

Added another constructor for DefaultGasProvider. The added constructor takes caver as a parameter and sets gasPrice via getGasPrice.

In addition, the create function that takes custom gas price as a parameter has been added to the classes implementing each TransactionTransformer.

In SmartContract class, when creating TransactionTransformer, change gasProvider of gasProvider as parameter.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

close https://github.com/klaytn/caver-java/issues/76

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
