### PR TITLE
Add condition in AccountKeyWeightedMultiSig.getRLPEncoding()

### DIFF
--- a/core/src/main/java/com/klaytn/caver/account/AccountKeyWeightedMultiSig.java
+++ b/core/src/main/java/com/klaytn/caver/account/AccountKeyWeightedMultiSig.java
@@ -142,9 +142,18 @@ public class AccountKeyWeightedMultiSig implements IAccountKey {
 
         List<RlpType> rlpWeightedPublicKeyList = new ArrayList<>();
         for(WeightedPublicKey item : this.weightedPublicKeys) {
+
+            if(item.getPublicKey() == null) {
+                throw new RuntimeException("public key should be specified for a multisig account");
+            }
+
+            if(item.getWeight() == null) {
+                throw new RuntimeException("weight should be specified for a multisig account");
+            }
+
             List<RlpType> rlpWeightedPublicKey = new ArrayList<>();
 
-            BigInteger weight = item.weight;
+            BigInteger weight = item.getWeight();
             String compressedKey = Utils.compressPublicKey(item.getPublicKey());
             rlpWeightedPublicKey.addAll(Arrays.asList(
                     RlpString.create(weight),


### PR DESCRIPTION
## Proposed changes

Add condition that WeightedMultiSig instance's fields has null, when executing AccountKeyWeightedMultiSig.getRLPEncoding()

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

related #97

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
