### PR TITLE
workaround handling Smart Contract overloading function

### DIFF
--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -51,6 +51,13 @@ public class ABI {
         return methodId + encodedParams;
     }
 
+    public static String encodeFunctionCall(String functionName, List<Type> params) {
+        String functionId = ABI.encodeFunctionSignature(ABI.buildFunctionString(functionName, params));
+        String encodedArguments = ABI.encodeParameters(params);
+
+        return functionId + encodedArguments;
+    }
+
     /**
      * Encodes a function signature.
      * @param method A ContractMethod instance.

--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -52,16 +52,16 @@ public class ABI {
     }
 
     /**
-     * Encodes a function call.
-     * @param functionName A function name.
-     * @param params A List of method parameter that wrapped solidity type wrapper class
+     * Encodes a function call
+     * @param method A ContractMethod instance.
+     * @param params A List of method parameter wrapped solidity wrapper class.
      * @return String
      */
-    public static String encodeFunctionCall(String functionName, List<Type> params) {
-        String functionId = ABI.encodeFunctionSignature(ABI.buildFunctionString(functionName, params));
+    public static String encodeFunctionCallWithSolidityWrapper(ContractMethod method, List<Type> params) {
+        String methodId = encodeFunctionSignature(method);
         String encodedArguments = ABI.encodeParameters(params);
 
-        return functionId + encodedArguments;
+        return methodId + encodedArguments;
     }
 
     /**
@@ -99,16 +99,6 @@ public class ABI {
         result.append(params);
         result.append(")");
 
-        return result.toString();
-    }
-
-    public static String buildFunctionString(String methodName, List<Type> parameters) {
-        StringBuilder result = new StringBuilder();
-        result.append(methodName);
-        result.append("(");
-        String params = parameters.stream().map(Type::getTypeAsString).collect(Collectors.joining(","));
-        result.append(params);
-        result.append(")");
         return result.toString();
     }
 

--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -89,6 +89,16 @@ public class ABI {
         return result.toString();
     }
 
+    public static String buildFunctionString(String methodName, List<Type> parameters) {
+        StringBuilder result = new StringBuilder();
+        result.append(methodName);
+        result.append("(");
+        String params = parameters.stream().map(Type::getTypeAsString).collect(Collectors.joining(","));
+        result.append(params);
+        result.append(")");
+        return result.toString();
+    }
+
     /**
      * Encodes a event signature.
      * @param event A ContractEvent instance.

--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -84,6 +84,17 @@ public class ABI {
         return Numeric.toHexString(hash).substring(0, 10);
     }
 
+    public static String encodeContractDeploy(ContractMethod constructor, String byteCode, List<Object> constructorParams) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        String encodedParam = "";
+
+        if(constructor != null) {
+            constructor.checkTypeValid(constructorParams);
+            encodedParam = ABI.encodeParameters(constructor, constructorParams);
+        }
+
+        return byteCode + encodedParam;
+    }
+
     /**
      * Build a function name string.
      * @param method A ContractMethod instance.

--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -84,6 +84,18 @@ public class ABI {
         return Numeric.toHexString(hash).substring(0, 10);
     }
 
+    /**
+     * Encodes a data related contract deployment.
+     * @param constructor A ContractMethod instance that contains constructor info.
+     * @param byteCode A smart contract bytecode.
+     * @param constructorParams A list of parameter that need to execute Constructor
+     * @return String
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
     public static String encodeContractDeploy(ContractMethod constructor, String byteCode, List<Object> constructorParams) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
         String encodedParam = "";
 

--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -51,6 +51,12 @@ public class ABI {
         return methodId + encodedParams;
     }
 
+    /**
+     * Encodes a function call.
+     * @param functionName A function name.
+     * @param params A List of method parameter that wrapped solidity type wrapper class
+     * @return String
+     */
     public static String encodeFunctionCall(String functionName, List<Type> params) {
         String functionId = ABI.encodeFunctionSignature(ABI.buildFunctionString(functionName, params));
         String encodedArguments = ABI.encodeParameters(params);

--- a/core/src/main/java/com/klaytn/caver/contract/Contract.java
+++ b/core/src/main/java/com/klaytn/caver/contract/Contract.java
@@ -275,7 +275,7 @@ public class Contract {
      * Setter function for Caver.
      * @param caver The Caver instance.
      */
-    public void setCaver(Caver caver) {
+    void setCaver(Caver caver) {
         this.caver = caver;
 
         //When Caver instance changes, the caver instance of each ContractMethod is also replaced.
@@ -289,7 +289,7 @@ public class Contract {
      * @param abi The abi json string.
      * @throws IOException
      */
-    public void setAbi(String abi) throws IOException {
+    void setAbi(String abi) throws IOException {
         this.abi = abi;
 
         //When abi changes, It newly set a "methods" and "events".
@@ -300,7 +300,7 @@ public class Contract {
      * Setter function for contract address.
      * @param contractAddress The contract address.
      */
-    public void setContractAddress(String contractAddress) {
+    void setContractAddress(String contractAddress) {
         this.contractAddress = contractAddress;
 
         //When contract address changes, the contract address of each ContractMethod is also replaced.
@@ -313,7 +313,7 @@ public class Contract {
      * Setter function for methods.
      * @param methods The map where method name string and ContractMethod mapped.
      */
-    public void setMethods(Map<String, ContractMethod> methods) {
+    void setMethods(Map<String, ContractMethod> methods) {
         this.methods = methods;
     }
 
@@ -321,7 +321,7 @@ public class Contract {
      * Setter function for events.
      * @param events The map where event name string and ContractEvent mapped.
      */
-    public void setEvents(Map<String, ContractEvent> events) {
+    void setEvents(Map<String, ContractEvent> events) {
         this.events = events;
     }
 
@@ -329,7 +329,7 @@ public class Contract {
      * Setter function for constructor.
      * @param constructor The ContractMethod instance related Contract's constructor.
      */
-    public void setConstructor(ContractMethod constructor) {
+    void setConstructor(ContractMethod constructor) {
         this.constructor = constructor;
     }
 

--- a/core/src/main/java/com/klaytn/caver/contract/Contract.java
+++ b/core/src/main/java/com/klaytn/caver/contract/Contract.java
@@ -379,7 +379,7 @@ public class Contract {
                     });
 
                     if(existedMethod.getInputs().size() == newMethod.getInputs().size() || isWarning) {
-                        LOGGER.warn("An overloaded function with the same number of parameters may not be executed normally.");
+                        LOGGER.warn("An overloaded function with the same number of parameters may not be executed normally. Please use *withSolidityWrapper methods in ContractMethod class.");
                     }
 
                     existedMethod.getNextContractMethods().add(newMethod);

--- a/core/src/main/java/com/klaytn/caver/contract/Contract.java
+++ b/core/src/main/java/com/klaytn/caver/contract/Contract.java
@@ -113,14 +113,7 @@ public class Contract {
      * @throws TransactionException
      */
     public Contract deploy(ContractDeployParams deployParam, SendOptions sendOptions, TransactionReceiptProcessor processor) throws IOException, TransactionException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-        String encodedParams = "";
-
-        if(this.getConstructor() != null) {
-            this.getConstructor().checkTypeValid(deployParam.getDeployParams());
-            encodedParams = ABI.encodeParameters(this.getConstructor(), deployParam.getDeployParams());
-        }
-
-        String input = deployParam.getBytecode() + encodedParams;
+        String input = ABI.encodeContractDeploy(this.getConstructor(), deployParam.getBytecode(), deployParam.getDeployParams());
 
         SmartContractDeploy smartContractDeploy = new SmartContractDeploy.Builder()
                 .setKlaytnCall(caver.rpc.klay)

--- a/core/src/main/java/com/klaytn/caver/contract/ContractEvent.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractEvent.java
@@ -83,7 +83,7 @@ public class ContractEvent {
      * Setter function for name.
      * @param name A function name.
      */
-    public void setName(String name) {
+    void setName(String name) {
         this.name = name;
     }
 
@@ -91,7 +91,7 @@ public class ContractEvent {
      * Setter function for type.
      * @param type The input type. It always set "event".
      */
-    public void setType(String type) {
+    void setType(String type) {
         this.type = type;
     }
 
@@ -99,7 +99,7 @@ public class ContractEvent {
      * Setter function for inputs
      * @param inputs The list of ContractIOType contains to function parameter information.
      */
-    public void setInputs(List<ContractIOType> inputs) {
+    void setInputs(List<ContractIOType> inputs) {
         this.inputs = inputs;
     }
 
@@ -107,7 +107,7 @@ public class ContractEvent {
      * Setter function for event signature.
      * @param signature A function signature
      */
-    public void setSignature(String signature) {
+    void setSignature(String signature) {
         this.signature = signature;
     }
 }

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -407,7 +407,7 @@ public class ContractMethod {
      * Setter function for Caver.
      * @param caver The Caver instance.
      */
-    public void setCaver(Caver caver) {
+    void setCaver(Caver caver) {
         this.caver = caver;
     }
 
@@ -415,7 +415,7 @@ public class ContractMethod {
      * Setter function for type.
      * @param type The input type. It always set "function".
      */
-    public void setType(String type) {
+    void setType(String type) {
         this.type = type;
     }
 
@@ -423,7 +423,7 @@ public class ContractMethod {
      * Setter function for name.
      * @param name A function name.
      */
-    public void setName(String name) {
+    void setName(String name) {
         this.name = name;
     }
 
@@ -431,7 +431,7 @@ public class ContractMethod {
      * Setter function for inputs
      * @param inputs The list of ContractIOType contains to function parameter information.
      */
-    public void setInputs(List<ContractIOType> inputs) {
+    void setInputs(List<ContractIOType> inputs) {
         this.inputs = inputs;
     }
 
@@ -439,7 +439,7 @@ public class ContractMethod {
      * Setter function for outputs
      * @param outputs The list of ContractIOTYpe contains to function return value information.
      */
-    public void setOutputs(List<ContractIOType> outputs) {
+    void setOutputs(List<ContractIOType> outputs) {
         this.outputs = outputs;
     }
 
@@ -447,7 +447,7 @@ public class ContractMethod {
      * Setter function for function signature.
      * @param signature A function signature
      */
-    public void setSignature(String signature) {
+    void setSignature(String signature) {
         this.signature = signature;
     }
 
@@ -455,7 +455,7 @@ public class ContractMethod {
      * Setter function for contract address
      * @param contractAddress A contract address.
      */
-    public void setContractAddress(String contractAddress) {
+    void setContractAddress(String contractAddress) {
         this.contractAddress = contractAddress;
         if(this.getNextContractMethods() != null && this.getNextContractMethods().size() != 0) {
             this.getNextContractMethods().stream().forEach(contractMethod -> {
@@ -468,11 +468,11 @@ public class ContractMethod {
      * Setter function for defaultSendOption
      * @param defaultSendOptions The sendOptions to set DefaultSendOptions field.
      */
-    public void setDefaultSendOptions(SendOptions defaultSendOptions) {
+    void setDefaultSendOptions(SendOptions defaultSendOptions) {
         this.defaultSendOptions = defaultSendOptions;
     }
 
-    public void setNextContractMethods(List<ContractMethod> nextContractMethods) {
+    void setNextContractMethods(List<ContractMethod> nextContractMethods) {
         this.nextContractMethods = nextContractMethods;
     }
 

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -247,9 +247,7 @@ public class ContractMethod {
         SendOptions sendOptions = makeSendOption(options);
         checkSendOption(sendOptions);
 
-        ContractMethod matchedMethod = findMatchedInstance(functionParams);
-
-        String functionId = ABI.encodeFunctionSignature(matchedMethod);
+        String functionId = ABI.encodeFunctionSignature(ABI.buildFunctionString(this.getName(), wrapperArguments));
         String encodedArguments = ABI.encodeParameters(wrapperArguments);
 
         String encodedFunction = functionId + encodedArguments;
@@ -264,7 +262,7 @@ public class ContractMethod {
                 .build();
 
         caver.wallet.sign(sendOptions.getFrom(), smartContractExecution);
-        Bytes32 txHash = caver.rpc.klay.sendRawTransaction(smartContractExecution.getRawTransaction()).send();
+        Bytes32 txHash = caver.rpc.klay.sendRawTransaction(smartContractExecution).send();
 
         TransactionReceipt.TransactionReceiptData receipt = processor.waitForTransactionReceipt(txHash.getResult());
         return receipt;

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -298,7 +298,7 @@ public class ContractMethod {
 
     /**
      * Encodes the ABI for this method. It returns 32-bit function signature hash plus the encoded passed parameters.
-     * @param arguments A List of parameter
+     * @param arguments A List of parameter to execute smart contract method.
      * @return The encoded ABI byte code to send via a transaction or call.
      * @throws ClassNotFoundException
      * @throws NoSuchMethodException

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -122,7 +122,7 @@ public class ContractMethod {
         ContractMethod matchedMethod = findMatchedInstance(functionParams);
         String encodedFunction = ABI.encodeFunctionCall(matchedMethod, arguments);
 
-        return callTransaction(encodedFunction, callObject);
+        return callFunction(encodedFunction, callObject);
     }
 
     /**
@@ -146,7 +146,7 @@ public class ContractMethod {
         ContractMethod matchedMethod = findMatchedInstanceWithSolidityWrapper(functionParams);
         String encodedFunction = ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, arguments);
 
-        return callTransaction(encodedFunction, callObject);
+        return callFunction(encodedFunction, callObject);
     }
 
     /**
@@ -598,7 +598,7 @@ public class ContractMethod {
         return receipt;
     }
 
-    private List<Type> callTransaction(String encodedInput, CallObject callObject) throws ClassNotFoundException, IOException {
+    private List<Type> callFunction(String encodedInput, CallObject callObject) throws ClassNotFoundException, IOException {
         if(callObject.getData() != null || callObject.getTo() != null) {
             LOGGER.warn("'to' and 'data' field in CallObject will overwrite.");
         }

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -301,7 +301,7 @@ public class ContractMethod {
 
     /**
      * Encodes the ABI for this method. It returns 32-bit function signature hash plus the encoded passed parameters.
-     * @param arguments A List of parameter to execute smart contract method.
+     * @param arguments A List of parameter to encode function signature and parameters
      * @return The encoded ABI byte code to send via a transaction or call.
      * @throws ClassNotFoundException
      * @throws NoSuchMethodException

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -122,7 +122,7 @@ public class ContractMethod {
         ContractMethod matchedMethod = findMatchedInstance(functionParams);
         String encodedFunction = ABI.encodeFunctionCall(matchedMethod, arguments);
 
-        return callFunction(encodedFunction, callObject);
+        return callFunction(matchedMethod, encodedFunction, callObject);
     }
 
     /**
@@ -146,7 +146,7 @@ public class ContractMethod {
         ContractMethod matchedMethod = findMatchedInstanceWithSolidityWrapper(functionParams);
         String encodedFunction = ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, arguments);
 
-        return callFunction(encodedFunction, callObject);
+        return callFunction(matchedMethod, encodedFunction, callObject);
     }
 
     /**
@@ -598,7 +598,7 @@ public class ContractMethod {
         return receipt;
     }
 
-    private List<Type> callFunction(String encodedInput, CallObject callObject) throws ClassNotFoundException, IOException {
+    private List<Type> callFunction(ContractMethod method, String encodedInput, CallObject callObject) throws ClassNotFoundException, IOException {
         if(callObject.getData() != null || callObject.getTo() != null) {
             LOGGER.warn("'to' and 'data' field in CallObject will overwrite.");
         }
@@ -607,6 +607,6 @@ public class ContractMethod {
         Bytes response = caver.rpc.klay.call(callObject).send();
 
         String encodedResult = response.getResult();
-        return ABI.decodeParameters(this, encodedResult);
+        return ABI.decodeParameters(method, encodedResult);
     }
 }

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -120,7 +120,7 @@ public class ContractMethod {
         }
 
         ContractMethod matchedMethod = findMatchedInstance(functionParams);
-        String encodedFunction = ABI.encodeFunctionCall(matchedMethod, arguments);
+        String encodedFunction = ABI.encodeFunctionCall(matchedMethod, functionParams);
 
         return callFunction(matchedMethod, encodedFunction, callObject);
     }
@@ -144,7 +144,7 @@ public class ContractMethod {
         }
 
         ContractMethod matchedMethod = findMatchedInstanceWithSolidityWrapper(functionParams);
-        String encodedFunction = ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, arguments);
+        String encodedFunction = ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, functionParams);
 
         return callFunction(matchedMethod, encodedFunction, callObject);
     }
@@ -206,7 +206,7 @@ public class ContractMethod {
         }
 
         ContractMethod matchedMethod = findMatchedInstance(functionParams);
-        String encodedFunction = ABI.encodeFunctionCall(matchedMethod, arguments);
+        String encodedFunction = ABI.encodeFunctionCall(matchedMethod, functionParams);
 
         return sendTransaction(matchedMethod, options, encodedFunction, processor);
     }

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -209,6 +209,21 @@ public class ContractMethod {
 
     /**
      * Send a transaction to smart contract and execute its method using solidity type wrapper class.
+     * It is used defaultSendOption field to sendOptions
+     * It sets TransactionReceiptProcessor to PollingTransactionReceiptProcessor.
+     * It is recommended to use this function when you want to execute one of the functions with the same number of parameters.
+     * @param wrapperArguments A List of parameter that wrapped solidity wrapper class.
+     * @param options An option to execute smart contract method.
+     * @return TransactionReceiptData
+     * @throws IOException
+     * @throws TransactionException
+     */
+    public TransactionReceipt.TransactionReceiptData sendWithSolidityWrapper(List<Type> wrapperArguments) throws IOException, TransactionException {
+        return sendWithSolidityWrapper(wrapperArguments, null, new PollingTransactionReceiptProcessor(caver, 1000, 15));
+    }
+
+    /**
+     * Send a transaction to smart contract and execute its method using solidity type wrapper class.
      * It sets TransactionReceiptProcessor to PollingTransactionReceiptProcessor.
      * It is recommended to use this function when you want to execute one of the functions with the same number of parameters.
      * @param wrapperArguments A List of parameter that wrapped solidity wrapper class.

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -107,6 +107,10 @@ public class ContractMethod {
      * @return List
      * @throws IOException
      * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
      */
     public List<Type> call(List<Object> arguments, CallObject callObject) throws IOException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
         List<Object> functionParams = new ArrayList<>();
@@ -140,7 +144,7 @@ public class ContractMethod {
         }
 
         ContractMethod matchedMethod = findMatchedInstanceWithSolidityWrapper(functionParams);
-        String encodedFunction = ABI.encodeFunctionCall(matchedMethod.getName(), arguments);
+        String encodedFunction = ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, arguments);
 
         return callTransaction(encodedFunction, callObject);
     }
@@ -252,7 +256,7 @@ public class ContractMethod {
             functionParams.addAll(wrapperArguments);
         }
         ContractMethod matchedMethod = findMatchedInstanceWithSolidityWrapper(functionParams);
-        String encodedFunction = ABI.encodeFunctionCall(matchedMethod.getName(), functionParams);
+        String encodedFunction = ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, functionParams);
 
         return sendTransaction(options, encodedFunction, processor);
     }
@@ -281,7 +285,7 @@ public class ContractMethod {
      */
     public String encodeABIWithSolidityWrapper(List<Type> arguments) {
         ContractMethod matchedMethod = this.findMatchedInstanceWithSolidityWrapper(arguments);
-        return ABI.encodeFunctionCall(matchedMethod.getName(), arguments);
+        return ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, arguments);
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/rpc/Klay.java
+++ b/core/src/main/java/com/klaytn/caver/rpc/Klay.java
@@ -8,10 +8,14 @@ import com.klaytn.caver.methods.response.Boolean;
 import com.klaytn.caver.methods.response.*;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.response.PollingTransactionReceiptProcessor;
+import com.klaytn.caver.transaction.response.TransactionReceiptProcessor;
 import com.klaytn.caver.utils.Utils;
 import org.web3j.protocol.Web3jService;
 import org.web3j.protocol.core.*;
+import org.web3j.protocol.exceptions.TransactionException;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -925,6 +929,21 @@ public class Klay {
         return new Request<>(
                 "klay_sendRawTransaction",
                 Arrays.asList(signedTransactionData),
+                web3jService,
+                Bytes32.class);
+    }
+
+    /**
+     * Creates a new message call transaction or a contract creation for signed transactions.
+     * @param transaction A transaction instance.
+     * @return Bytes32
+     */
+    public Request<?, Bytes32> sendRawTransaction(AbstractTransaction transaction) {
+        String rawTransaction = transaction.getRLPEncoding();
+
+        return new Request<>(
+                "klay_sendRawTransaction",
+                Arrays.asList(rawTransaction),
                 web3jService,
                 Bytes32.class);
     }

--- a/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
@@ -1,0 +1,198 @@
+package com.klaytn.caver.common;
+
+import com.klaytn.caver.Caver;
+import com.klaytn.caver.contract.Contract;
+import com.klaytn.caver.contract.ContractDeployParams;
+import com.klaytn.caver.contract.SendOptions;
+import com.klaytn.caver.methods.request.CallObject;
+import com.klaytn.caver.wallet.keyring.KeyringFactory;
+import org.intellij.lang.annotations.Language;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.Utf8String;
+import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.protocol.exceptions.TransactionException;
+import org.web3j.tx.gas.DefaultGasProvider;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.klaytn.caver.base.Accounts.LUMAN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ContractOverloadFunctionsTest {
+    static final String BYTECODE = "608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167f342827c97908e5e2f71151c08502a66d44b6f758e3ac2f1de95f02eb95f0a73560405160405180910390a3610905806100dc6000396000f3fe608060405234801561001057600080fd5b50600436106100625760003560e01c8063145ef6e9146100675780633b710f8c146100ea57806356df3db1146101c5578063893d20e814610213578063a6f9dae11461025d578063a7db555b146102a1575b600080fd5b61006f6102bf565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100af578082015181840152602081019050610094565b50505050905090810190601f1680156100dc5780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6101c36004803603604081101561010057600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291908035906020019064010000000081111561013d57600080fd5b82018360208201111561014f57600080fd5b8035906020019184600183028401116401000000008311171561017157600080fd5b91908080601f016020809104026020016040519081016040528093929190818152602001838380828437600081840152601f19601f820116905080830192505050505050509192919290505050610361565b005b610211600480360360408110156101db57600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190803590602001909291905050506104f9565b005b61021b610681565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b61029f6004803603602081101561027357600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506106aa565b005b6102a961082a565b6040518082815260200191505060405180910390f35b606060018054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156103575780601f1061032c57610100808354040283529160200191610357565b820191906000526020600020905b81548152906001019060200180831161033a57829003601f168201915b5050505050905090565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614610423576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260138152602001807f43616c6c6572206973206e6f74206f776e65720000000000000000000000000081525060200191505060405180910390fd5b8173ffffffffffffffffffffffffffffffffffffffff166000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff167f342827c97908e5e2f71151c08502a66d44b6f758e3ac2f1de95f02eb95f0a73560405160405180910390a3816000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555080600190805190602001906104f4929190610834565b505050565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16146105bb576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260138152602001807f43616c6c6572206973206e6f74206f776e65720000000000000000000000000081525060200191505060405180910390fd5b8173ffffffffffffffffffffffffffffffffffffffff166000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff167f342827c97908e5e2f71151c08502a66d44b6f758e3ac2f1de95f02eb95f0a73560405160405180910390a3816000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550806002819055505050565b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16905090565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161461076c576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260138152602001807f43616c6c6572206973206e6f74206f776e65720000000000000000000000000081525060200191505060405180910390fd5b8073ffffffffffffffffffffffffffffffffffffffff166000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff167f342827c97908e5e2f71151c08502a66d44b6f758e3ac2f1de95f02eb95f0a73560405160405180910390a3806000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050565b6000600254905090565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061087557805160ff19168380011785556108a3565b828001600101855582156108a3579182015b828111156108a2578251825591602001919060010190610887565b5b5090506108b091906108b4565b5090565b6108d691905b808211156108d25760008160009055506001016108ba565b5090565b9056fea165627a7a723058201024bd6f9780fc8257377e0719756900b6734eff21bdb2715e228c67a864f7600029";
+    static final String ABIJson = "[\n" +
+            "  {\n" +
+            "    \"constant\": true,\n" +
+            "    \"inputs\": [],\n" +
+            "    \"name\": \"getOwnerName\",\n" +
+            "    \"outputs\": [\n" +
+            "      {\n" +
+            "        \"name\": \"\",\n" +
+            "        \"type\": \"string\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"payable\": false,\n" +
+            "    \"stateMutability\": \"view\",\n" +
+            "    \"type\": \"function\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"constant\": false,\n" +
+            "    \"inputs\": [\n" +
+            "      {\n" +
+            "        \"name\": \"newOwner\",\n" +
+            "        \"type\": \"address\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"name\": \"name\",\n" +
+            "        \"type\": \"string\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"name\": \"changeOwner\",\n" +
+            "    \"outputs\": [],\n" +
+            "    \"payable\": false,\n" +
+            "    \"stateMutability\": \"nonpayable\",\n" +
+            "    \"type\": \"function\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"constant\": false,\n" +
+            "    \"inputs\": [\n" +
+            "      {\n" +
+            "        \"name\": \"newOwner\",\n" +
+            "        \"type\": \"address\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"name\": \"number\",\n" +
+            "        \"type\": \"uint256\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"name\": \"changeOwner\",\n" +
+            "    \"outputs\": [],\n" +
+            "    \"payable\": false,\n" +
+            "    \"stateMutability\": \"nonpayable\",\n" +
+            "    \"type\": \"function\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"constant\": true,\n" +
+            "    \"inputs\": [],\n" +
+            "    \"name\": \"getOwner\",\n" +
+            "    \"outputs\": [\n" +
+            "      {\n" +
+            "        \"name\": \"\",\n" +
+            "        \"type\": \"address\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"payable\": false,\n" +
+            "    \"stateMutability\": \"view\",\n" +
+            "    \"type\": \"function\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"constant\": false,\n" +
+            "    \"inputs\": [\n" +
+            "      {\n" +
+            "        \"name\": \"newOwner\",\n" +
+            "        \"type\": \"address\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"name\": \"changeOwner\",\n" +
+            "    \"outputs\": [],\n" +
+            "    \"payable\": false,\n" +
+            "    \"stateMutability\": \"nonpayable\",\n" +
+            "    \"type\": \"function\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"constant\": true,\n" +
+            "    \"inputs\": [],\n" +
+            "    \"name\": \"getOwnerNumber\",\n" +
+            "    \"outputs\": [\n" +
+            "      {\n" +
+            "        \"name\": \"\",\n" +
+            "        \"type\": \"uint256\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"payable\": false,\n" +
+            "    \"stateMutability\": \"view\",\n" +
+            "    \"type\": \"function\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"inputs\": [],\n" +
+            "    \"payable\": false,\n" +
+            "    \"stateMutability\": \"nonpayable\",\n" +
+            "    \"type\": \"constructor\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"anonymous\": false,\n" +
+            "    \"inputs\": [\n" +
+            "      {\n" +
+            "        \"indexed\": true,\n" +
+            "        \"name\": \"oldOwner\",\n" +
+            "        \"type\": \"address\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"indexed\": true,\n" +
+            "        \"name\": \"newOwner\",\n" +
+            "        \"type\": \"address\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"name\": \"OwnerSet\",\n" +
+            "    \"type\": \"event\"\n" +
+            "  }\n" +
+            "]";
+
+    public static String contractAddress = "";
+    public static String ownerPrivateKey = "0x2359d1ae7317c01532a58b01452476b796a3ac713336e97d8d3c9651cc0aecc3";
+
+    @BeforeClass
+    public static void deploy() {
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+        caver.wallet.add(KeyringFactory.createFromPrivateKey(ownerPrivateKey));
+
+        SendOptions options = new SendOptions(LUMAN.getAddress(), DefaultGasProvider.GAS_LIMIT);
+        ContractDeployParams contractDeployParam = new ContractDeployParams(BYTECODE, null);
+
+        try {
+            Contract contract = new Contract(caver, ABIJson);
+            contract.deploy(contractDeployParam, options);
+            contractAddress = contract.getContractAddress();
+        } catch (IOException | TransactionException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            fail();
+        }
+
+    }
+
+    @Test
+    public void overloadFunctionTest() {
+        String methodName = "changeOwner";
+
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+        caver.wallet.add(KeyringFactory.createFromPrivateKey(ownerPrivateKey));
+
+        SendOptions options = new SendOptions(LUMAN.getAddress(), DefaultGasProvider.GAS_LIMIT);
+
+        try {
+            Contract contract = new Contract(caver, ABIJson, contractAddress);
+            contract.getMethod(methodName).sendWithSolidityWrapper(Arrays.asList(new Address(LUMAN.getAddress()), new Utf8String("LUMAN")), options);
+            List<Type> result = contract.getMethod("getOwnerName").call(null, CallObject.createCallObject());
+            assertEquals("LUMAN", result.get(0).getValue());
+
+            contract.getMethod(methodName).sendWithSolidityWrapper(Arrays.asList(new Address(LUMAN.getAddress()), new Uint256(BigInteger.valueOf(1234))), options);
+            result = contract.getMethod("getOwnerName").call(null, CallObject.createCallObject());
+            System.out.println(result.get(0).getValue());
+
+            result = contract.getMethod("getOwnerNumber").call(null, CallObject.createCallObject());
+            assertEquals(1234, ((BigInteger)result.get(0).getValue()).intValue());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+
+}

--- a/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
@@ -6,7 +6,6 @@ import com.klaytn.caver.contract.ContractDeployParams;
 import com.klaytn.caver.contract.SendOptions;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.wallet.keyring.KeyringFactory;
-import org.intellij.lang.annotations.Language;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.web3j.abi.datatypes.Address;

--- a/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
@@ -203,7 +203,7 @@ public class ContractOverloadFunctionsTest {
         try {
             Contract contract = new Contract(caver, ABIJson, contractAddress);
 
-            List<Type> result = contract.getMethod(methodName).call(null, CallObject.createCallObject());
+            List<Type> result = contract.getMethod(methodName).callWithSolidityWrapper(null, CallObject.createCallObject());
             assertEquals(LUMAN.getAddress(), ((Address)result.get(0)).getValue());
 
         } catch (Exception e) {

--- a/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
@@ -194,5 +194,45 @@ public class ContractOverloadFunctionsTest {
         }
     }
 
+    @Test
+    public void callWithSolidityWrapperTest() {
+        String methodName = "getOwner";
+
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+        caver.wallet.add(KeyringFactory.createFromPrivateKey(ownerPrivateKey));
+
+        try {
+            Contract contract = new Contract(caver, ABIJson, contractAddress);
+
+            List<Type> result = contract.getMethod(methodName).call(null, CallObject.createCallObject());
+            assertEquals(LUMAN.getAddress(), ((Address)result.get(0)).getValue());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void encodeABIWithSolidityWrapperTest() {
+        String methodName = "changeOwner";
+
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+        caver.wallet.add(KeyringFactory.createFromPrivateKey(ownerPrivateKey));
+
+        SendOptions options = new SendOptions(LUMAN.getAddress(), DefaultGasProvider.GAS_LIMIT);
+
+        try {
+            Contract contract = new Contract(caver, ABIJson, contractAddress);
+            String expected = contract.getMethod(methodName).encodeABI(Arrays.asList(LUMAN.getAddress()));
+            String actual = contract.getMethod(methodName).encodeABIWithSolidityWrapper(Arrays.asList(new Address(LUMAN.getAddress())));
+
+            assertEquals(expected, actual);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
 
 }

--- a/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
@@ -439,7 +439,7 @@ public class KIP17Test {
 
                 BigInteger preBalance = kip17Contract.balanceOf(LUMAN.getAddress());
 
-                BigInteger tokenId = BigInteger.ZERO;
+                BigInteger tokenId = BigInteger.valueOf(100000);
                 SendOptions sendOptions = new SendOptions(LUMAN.getAddress(), (String)null);
                 kip17Contract.mint(LUMAN.getAddress(), tokenId, sendOptions);
 


### PR DESCRIPTION
## Proposed changes

This PR implements below contents:
If smart contract has functions with the same number of parameters, it will work abnormally.
because caver passed parameter for executing smart contract's function, it is difficult to decide which of the functions will be executed. 

To resolve the this issue, I define functions with wrapped passed parameter type as a solidity type wrapper class.
The advantage of this method is that it can check which function to execute with only the parameter information.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

related #97 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
