### PR TITLE
add getBlockTransactionCountByHash and getBlockTransactionCountByNumber

### DIFF
--- a/core/src/main/java/com/klaytn/caver/rpc/Klay.java
+++ b/core/src/main/java/com/klaytn/caver/rpc/Klay.java
@@ -472,6 +472,24 @@ public class Klay {
      * @param blockNumber The block number.
      * @return Quantity
      */
+    public Request<?, Quantity> getBlockTransactionCountByNumber(long blockNumber) {
+        return getTransactionCountByNumber(blockNumber);
+    }
+
+    /**
+     * Returns the number of transactions in a block matching the given block number.
+     * @param blockTag The string "latest", "earliest" or "pending"
+     * @return Quantity
+     */
+    public Request<?, Quantity> getBlockTransactionCountByNumber(DefaultBlockParameter blockTag) {
+        return getTransactionCountByNumber(blockTag);
+    }
+
+    /**
+     * Returns the number of transactions in a block matching the given block number.
+     * @param blockNumber The block number.
+     * @return Quantity
+     */
     public Request<?, Quantity> getTransactionCountByNumber(long blockNumber) {
         DefaultBlockParameterNumber blockParameterNumber = new DefaultBlockParameterNumber(blockNumber);
         return getTransactionCountByNumber(blockParameterNumber);
@@ -488,6 +506,15 @@ public class Klay {
                 Arrays.asList(blockTag),
                 web3jService,
                 Quantity.class);
+    }
+
+    /**
+     * Returns the number of transactions in a block from a block matching the given block hash.
+     * @param blockHash The hash of a block
+     * @return Quantity
+     */
+    public Request<?, Quantity> getBlockTransactionCountByHash(String blockHash) {
+        return getTransactionCountByHash(blockHash);
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/rpc/Klay.java
+++ b/core/src/main/java/com/klaytn/caver/rpc/Klay.java
@@ -473,24 +473,6 @@ public class Klay {
      * @return Quantity
      */
     public Request<?, Quantity> getBlockTransactionCountByNumber(long blockNumber) {
-        return getTransactionCountByNumber(blockNumber);
-    }
-
-    /**
-     * Returns the number of transactions in a block matching the given block number.
-     * @param blockTag The string "latest", "earliest" or "pending"
-     * @return Quantity
-     */
-    public Request<?, Quantity> getBlockTransactionCountByNumber(DefaultBlockParameter blockTag) {
-        return getTransactionCountByNumber(blockTag);
-    }
-
-    /**
-     * Returns the number of transactions in a block matching the given block number.
-     * @param blockNumber The block number.
-     * @return Quantity
-     */
-    public Request<?, Quantity> getTransactionCountByNumber(long blockNumber) {
         DefaultBlockParameterNumber blockParameterNumber = new DefaultBlockParameterNumber(blockNumber);
         return getTransactionCountByNumber(blockParameterNumber);
     }
@@ -500,7 +482,7 @@ public class Klay {
      * @param blockTag The string "latest", "earliest" or "pending"
      * @return Quantity
      */
-    public Request<?, Quantity> getTransactionCountByNumber(DefaultBlockParameter blockTag) {
+    public Request<?, Quantity> getBlockTransactionCountByNumber(DefaultBlockParameter blockTag) {
         return new Request<>(
                 "klay_getBlockTransactionCountByNumber",
                 Arrays.asList(blockTag),
@@ -509,12 +491,34 @@ public class Klay {
     }
 
     /**
+     * Returns the number of transactions in a block matching the given block number.
+     * @param blockNumber The block number.
+     * @return Quantity
+     */
+    public Request<?, Quantity> getTransactionCountByNumber(long blockNumber) {
+        return getBlockTransactionCountByNumber(blockNumber);
+    }
+
+    /**
+     * Returns the number of transactions in a block matching the given block number.
+     * @param blockTag The string "latest", "earliest" or "pending"
+     * @return Quantity
+     */
+    public Request<?, Quantity> getTransactionCountByNumber(DefaultBlockParameter blockTag) {
+        return getBlockTransactionCountByNumber(blockTag);
+    }
+
+    /**
      * Returns the number of transactions in a block from a block matching the given block hash.
      * @param blockHash The hash of a block
      * @return Quantity
      */
     public Request<?, Quantity> getBlockTransactionCountByHash(String blockHash) {
-        return getTransactionCountByHash(blockHash);
+        return new Request<>(
+                "klay_getBlockTransactionCountByHash",
+                Arrays.asList(blockHash),
+                web3jService,
+                Quantity.class);
     }
 
     /**
@@ -523,11 +527,7 @@ public class Klay {
      * @return Quantity
      */
     public Request<?, Quantity> getTransactionCountByHash(String blockHash) {
-        return new Request<>(
-                "klay_getBlockTransactionCountByHash",
-                Arrays.asList(blockHash),
-                web3jService,
-                Quantity.class);
+        return getBlockTransactionCountByHash(blockHash);
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

This PR add function getBlockTransactionCountByHash(), getBlockTransactionCountByNumber().
These functions have the same behavior as  getTransactionCountByHash(), getTransactionCountByNumber().


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
