### PR TITLE
Modify method in ContractMethod class.

### DIFF
--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -147,7 +147,6 @@ public class ContractMethod {
      * The 'data', 'to' fields automatically filled in call() method.
      * It is recommended to use this function when you want to execute one of the functions with the same number of parameters.
      * @param arguments A List of parameter that solidity wrapper type to call smart contract method.
-     * @param callObject A CallObject instance to 'call' smart contract method.
      * @return List
      * @throws IOException
      * @throws ClassNotFoundException
@@ -316,7 +315,7 @@ public class ContractMethod {
     /**
      * Encodes the ABI for this method. It returns 32-bit function signature hash plus the encoded passed parameters.
      * It is recommended to use this function when you want to execute one of the functions with the same number of parameters.
-     * @param arguments A List of parameter that solidity wrapper class
+     * @param wrapperArguments A List of parameter that solidity wrapper class
      * @return The encoded ABI byte code to send via a transaction or call.
      */
     public String encodeABIWithSolidityWrapper(List<Type> wrapperArguments) {

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -303,8 +303,13 @@ public class ContractMethod {
      * @throws InvocationTargetException
      */
     public String encodeABI(List<Object> arguments) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-        ContractMethod matchedMethod = findMatchedInstance(arguments);
+        List<Object> functionParams = new ArrayList<>();
 
+        if(arguments != null) {
+            functionParams.addAll(arguments);
+        }
+
+        ContractMethod matchedMethod = findMatchedInstance(functionParams);
         return ABI.encodeFunctionCall(matchedMethod, arguments);
     }
 
@@ -314,9 +319,15 @@ public class ContractMethod {
      * @param arguments A List of parameter that solidity wrapper class
      * @return The encoded ABI byte code to send via a transaction or call.
      */
-    public String encodeABIWithSolidityWrapper(List<Type> arguments) {
-        ContractMethod matchedMethod = this.findMatchedInstanceWithSolidityWrapper(arguments);
-        return ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, arguments);
+    public String encodeABIWithSolidityWrapper(List<Type> wrapperArguments) {
+        List<Type> functionParams = new ArrayList<>();
+
+        if(wrapperArguments != null) {
+            functionParams.addAll(wrapperArguments);
+        }
+
+        ContractMethod matchedMethod = this.findMatchedInstanceWithSolidityWrapper(functionParams);
+        return ABI.encodeFunctionCallWithSolidityWrapper(matchedMethod, functionParams);
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -103,6 +103,23 @@ public class ContractMethod {
      * When creating CallObject, it need not to fill 'data', 'to' fields.
      * The 'data', 'to' fields automatically filled in call() method.
      * @param arguments A List of parameter to call smart contract method.
+     * @return List
+     * @throws IOException
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public List<Type> call(List<Object> arguments) throws IOException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        return call(arguments, CallObject.createCallObject());
+    }
+
+    /**
+     * Execute smart contract method in the EVM without sending any transaction.
+     * When creating CallObject, it need not to fill 'data', 'to' fields.
+     * The 'data', 'to' fields automatically filled in call() method.
+     * @param arguments A List of parameter to call smart contract method.
      * @param callObject A CallObject instance to 'call' smart contract method.
      * @return List
      * @throws IOException
@@ -123,6 +140,20 @@ public class ContractMethod {
         String encodedFunction = ABI.encodeFunctionCall(matchedMethod, functionParams);
 
         return callFunction(matchedMethod, encodedFunction, callObject);
+    }
+
+    /**
+     * Execute smart contract method in the EVM without sending any transaction.
+     * The 'data', 'to' fields automatically filled in call() method.
+     * It is recommended to use this function when you want to execute one of the functions with the same number of parameters.
+     * @param arguments A List of parameter that solidity wrapper type to call smart contract method.
+     * @param callObject A CallObject instance to 'call' smart contract method.
+     * @return List
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public List<Type> callWithSolidityWrapper(List<Type> arguments) throws IOException, ClassNotFoundException {
+        return callWithSolidityWrapper(arguments, CallObject.createCallObject());
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -142,7 +142,6 @@ public class ContractMethod {
 
     /**
      * Execute smart contract method in the EVM without sending any transaction.
-     * The 'data', 'to' fields automatically filled in call() method.
      * It is recommended to use this function when you want to execute one of the functions with the same number of parameters.
      * @param arguments A List of parameter that solidity wrapper type to call smart contract method.
      * @return List

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -100,8 +100,6 @@ public class ContractMethod {
 
     /**
      * Execute smart contract method in the EVM without sending any transaction.
-     * When creating CallObject, it need not to fill 'data', 'to' fields.
-     * The 'data', 'to' fields automatically filled in call() method.
      * @param arguments A List of parameter to call smart contract method.
      * @return List
      * @throws IOException

--- a/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ContractOverloadFunctionsTest.java
@@ -213,6 +213,25 @@ public class ContractOverloadFunctionsTest {
     }
 
     @Test
+    public void callWithSolidityWrapperNoCallObjectTest() {
+        String methodName = "getOwner";
+
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+        caver.wallet.add(KeyringFactory.createFromPrivateKey(ownerPrivateKey));
+
+        try {
+            Contract contract = new Contract(caver, ABIJson, contractAddress);
+
+            List<Type> result = contract.getMethod(methodName).callWithSolidityWrapper(null);
+            assertEquals(LUMAN.getAddress(), ((Address)result.get(0)).getValue());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
     public void encodeABIWithSolidityWrapperTest() {
         String methodName = "changeOwner";
 

--- a/core/src/test/java/com/klaytn/caver/common/ContractTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ContractTest.java
@@ -863,6 +863,24 @@ public class ContractTest {
     }
 
     @Test
+    public void callWithNoCallObject() throws IOException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+
+        Contract contract = new Contract(caver, jsonObj, contractAddress);
+        CallObject callObject = CallObject.createCallObject(
+                LUMAN.getAddress(),
+                contractAddress,
+                null,
+                null,
+                null);
+
+        List<Type> result = contract.getMethod("symbol").call(null);
+
+        Utf8String symbol = (Utf8String)result.get(0);
+        assertEquals("KCT", symbol.getValue());
+    }
+
+    @Test
     public void send() throws IOException, TransactionException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
         Caver caver = new Caver(Caver.DEFAULT_URL);
         caver.wallet.add(KeyringFactory.createFromPrivateKey("0x2359d1ae7317c01532a58b01452476b796a3ac713336e97d8d3c9651cc0aecc3"));


### PR DESCRIPTION
## Proposed changes

This PR has the following contents.
  - add call(List<Object> argument) / callWithSolidityWrapper(List<Type> argument) method in ContractMethod. 
    - From now on, even if user don't need to create a CallObject instance, it is created internally.
    - If the function of the smart contract you want to call requires access permission, it maybe need customized CallObject instance.
  - modified encodeABI(), encodeABISolidityWrapper()
    - It handles the case when passed null parameter in these functions.
## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

related #97 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
