### PR TITLE
Modified isValidPublicKey function to handle 04 uncompressed prefixed public key

### DIFF
--- a/core/src/main/java/com/klaytn/caver/utils/AccountKeyPublicUtils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/AccountKeyPublicUtils.java
@@ -148,6 +148,10 @@ public class AccountKeyPublicUtils {
     public static boolean isUncompressedPublicKey(String key) {
         String noPrefixKey = Numeric.cleanHexPrefix(key);
 
+        if(noPrefixKey.length() == 130 && noPrefixKey.startsWith("04")) {
+            noPrefixKey = noPrefixKey.substring(2);
+        }
+
         if(noPrefixKey.length() == 128) {
             String x = noPrefixKey.substring(0, 64);
             String y = noPrefixKey.substring(64);

--- a/core/src/main/java/com/klaytn/caver/utils/Utils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/Utils.java
@@ -89,8 +89,12 @@ public class Utils {
      */
     public static boolean isValidPublicKey(String publicKey) {
         String noPrefixPubKey = Numeric.cleanHexPrefix(publicKey);
-        ECPoint point = null;
         boolean result;
+
+        if(noPrefixPubKey.length() == 130 && noPrefixPubKey.startsWith("04")) {
+            noPrefixPubKey = noPrefixPubKey.substring(2);
+        }
+
         if(noPrefixPubKey.length() != 66 && noPrefixPubKey.length() != 128) {
             return false;
         }

--- a/core/src/main/java/com/klaytn/caver/utils/Utils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/Utils.java
@@ -118,15 +118,15 @@ public class Utils {
     /**
      * Convert a compressed public key to an uncompressed format.
      * Given public key has already uncompressed format, it will return
-     * @param compressedPublicKey public key string(uncompressed or compressed)
+     * @param publicKey public key string(uncompressed or compressed)
      * @return uncompressed public key string
      */
-    public static String decompressPublicKey(String compressedPublicKey) {
-        if(AccountKeyPublicUtils.isUncompressedPublicKey(compressedPublicKey)) {
-            return compressedPublicKey;
+    public static String decompressPublicKey(String publicKey) {
+        if(AccountKeyPublicUtils.isUncompressedPublicKey(publicKey)) {
+            return publicKey;
         }
 
-        ECPoint ecPoint = AccountKeyPublicUtils.getECPoint(compressedPublicKey);
+        ECPoint ecPoint = AccountKeyPublicUtils.getECPoint(publicKey);
         String pointXY = Numeric.toHexStringWithPrefixZeroPadded(ecPoint.getAffineXCoord().toBigInteger(), 64) +
                 Numeric.toHexStringNoPrefixZeroPadded(ecPoint.getAffineYCoord().toBigInteger(), 64);
         return pointXY;
@@ -143,8 +143,13 @@ public class Utils {
             return publicKey;
         }
 
-        BigInteger publicKeyBN = Numeric.toBigInt(publicKey);
         String noPrefixKey = Numeric.cleanHexPrefix(publicKey);
+        if(noPrefixKey.length() == 130 && noPrefixKey.startsWith("04")) {
+            noPrefixKey = noPrefixKey.substring(2);
+        }
+
+        BigInteger publicKeyBN = Numeric.toBigInt(noPrefixKey);
+
 
         String publicKeyX = noPrefixKey.substring(0, 64);
         String pubKeyYPrefix = publicKeyBN.testBit(0) ? "03" : "02";

--- a/core/src/test/java/com/klaytn/caver/common/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/UtilsTest.java
@@ -175,6 +175,14 @@ public class UtilsTest {
             assertTrue(Utils.isValidPublicKey(actualUncompressed));
             assertEquals(expectedUncompressed, actualUncompressed);
         }
+
+        @Test
+        public void alreadyDecompressedKeyWithTag() {
+            String expected = "0x04019b186993b620455077b6bc37bf61666725d8d87ab33eb113ac0414cd48d78ff46e5ea48c6f22e8f19a77e5dbba9d209df60cbcb841b7e3e81fe444ba829831";
+            String key = Utils.decompressPublicKey(expected);
+
+            assertEquals(expected, key);
+        }
     }
 
     public static class compressedPublicKeyTest {
@@ -192,6 +200,14 @@ public class UtilsTest {
             String actualCompressed = Utils.compressPublicKey(expectedCompressed);
             assertTrue(Utils.isValidPublicKey(actualCompressed));
             assertEquals(expectedCompressed, actualCompressed);
+        }
+
+        @Test
+        public void compressedPublicKeyWithTag() {
+            String key = "0x04019b186993b620455077b6bc37bf61666725d8d87ab33eb113ac0414cd48d78ff46e5ea48c6f22e8f19a77e5dbba9d209df60cbcb841b7e3e81fe444ba829831";
+            String expected = Utils.compressPublicKey("019b186993b620455077b6bc37bf61666725d8d87ab33eb113ac0414cd48d78ff46e5ea48c6f22e8f19a77e5dbba9d209df60cbcb841b7e3e81fe444ba829831");
+
+            assertEquals(expected, Utils.compressPublicKey(key));
         }
     }
 

--- a/core/src/test/java/com/klaytn/caver/common/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/UtilsTest.java
@@ -118,6 +118,12 @@ public class UtilsTest {
         }
 
         @Test
+        public void uncompressedKeyWithTagTest() {
+            String key = "0x04019b186993b620455077b6bc37bf61666725d8d87ab33eb113ac0414cd48d78ff46e5ea48c6f22e8f19a77e5dbba9d209df60cbcb841b7e3e81fe444ba829831";
+            assertTrue(Utils.isValidPublicKey(key));
+        }
+
+        @Test
         public void compressedKeyTest() {
             String key = KeyringFactory.generate().getPublicKey();
             key = Utils.compressPublicKey(key);


### PR DESCRIPTION
## Proposed changes

This PR introduces handling logic for 04-prefixed public key string in caver.utils.isValidPublicKey function.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
