### PR TITLE
unified key value in in-memory wallet.

### DIFF
--- a/core/src/main/java/com/klaytn/caver/wallet/KeyringContainer.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/KeyringContainer.java
@@ -154,7 +154,7 @@ public class KeyringContainer {
         }
 
         AbstractKeyring added = keyring.copy();
-        this.addressKeyringMap.put(keyring.getAddress(), added);
+        this.addressKeyringMap.put(keyring.getAddress().toLowerCase(), added);
 
         return added;
     }

--- a/core/src/test/java/com/klaytn/caver/common/KeyringContainerTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/KeyringContainerTest.java
@@ -356,6 +356,18 @@ public class KeyringContainerTest {
 
             container.getKeyring(invalidAddress);
         }
+
+        @Test
+        public void upperCaseAddress() {
+            String address = "0x37223E5E41186A782e4A1F709829F521f43b18E5";
+            SingleKeyring keyring = KeyringFactory.create(address, PrivateKey.generate().getPrivateKey());
+
+            KeyringContainer container = new KeyringContainer();
+            container.add(keyring);
+
+            assertNotNull(container.getKeyring(address));
+            assertEquals(address, container.getKeyring(address).getAddress());
+        }
     }
 
     public static class addTest {
@@ -435,6 +447,7 @@ public class KeyringContainerTest {
             validateRoleBasedKeyring(added, address, expectPrivateKeyArr);
             validateRoleBasedKeyring(fromContainer, address, expectPrivateKeyArr);
         }
+
     }
 
     public static class removeTest {


### PR DESCRIPTION
## Proposed changes

This PR unified key value in in-memory wallet.
When adding keyring instance to wallet, the keyring's address(used key in in-memory wallet) converts lowercase.
Also, when getting keyring instance form wallet, the address to find keyring converts lowercase.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues



## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
