### PR TITLE
Reduces caver-java test time.

### DIFF
--- a/core/src/test/java/com/klaytn/caver/common/AccountKeyTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/AccountKeyTest.java
@@ -17,8 +17,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({AccountKeyTest.AccountKeyFailTests.class, AccountKeyTest.AccountKeyLegacyTest.class, AccountKeyTest.AccountKeyPublicTest.class, AccountKeyTest.AccountKeyWeightedMultiSigTest.class, AccountKeyTest.AccountKeyRoleBasedTest.class})
 public class AccountKeyTest {
 
     public static class AccountKeyFailTests {

--- a/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
@@ -25,15 +25,6 @@ import static com.klaytn.caver.base.Accounts.BRANDON;
 import static com.klaytn.caver.base.Accounts.LUMAN;
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        KIP17Test.ConstructorTest.class,
-        KIP17Test.PausableTest.class,
-        KIP17Test.BurnableTest.class,
-        KIP17Test.MintableTest.class,
-        KIP17Test.CommonTest.class,
-        KIP17Test.EnumerableTest.class
-})
 public class KIP17Test {
     public static KIP17 kip17Contract;
     public static final String CONTRACT_NAME = "NFT";

--- a/core/src/test/java/com/klaytn/caver/common/KIP7Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP7Test.java
@@ -22,14 +22,6 @@ import java.math.BigInteger;
 import static com.klaytn.caver.base.Accounts.*;
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        KIP7Test.ConstructorTest.class,
-        KIP7Test.PausableTest.class,
-        KIP7Test.BurnableTest.class,
-        KIP7Test.MintableTest.class,
-        KIP7Test.CommonTest.class
-})
 public class KIP7Test {
 
     public static KIP7 kip7contract;

--- a/core/src/test/java/com/klaytn/caver/common/KeyringContainerTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/KeyringContainerTest.java
@@ -22,16 +22,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        KeyringContainerTest.generateTest.class,
-        KeyringContainerTest.newKeyringTest.class,
-        KeyringContainerTest.updateKeyringTest.class,
-        KeyringContainerTest.getKeyringTest.class,
-        KeyringContainerTest.addTest.class,
-        KeyringContainerTest.removeTest.class,
-        KeyringContainerTest.signMessageTest.class
-})
 public class KeyringContainerTest {
 
     static void validateSingleKeyring(AbstractKeyring actual, String expectAddress, String expectKey) {

--- a/core/src/test/java/com/klaytn/caver/common/KeyringTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/KeyringTest.java
@@ -19,29 +19,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        KeyringTest.generateTest.class,
-        KeyringTest.createFromPrivateKeyTest.class,
-        KeyringTest.createFromKlaytnWalletKeyTest.class,
-        KeyringTest.createTest.class,
-        KeyringTest.createWithSingleKeyTest.class,
-        KeyringTest.createWithMultipleKeyTest.class,
-        KeyringTest.createWithRoleBasedKeyTest.class,
-        KeyringTest.copyTest.class,
-        KeyringTest.signWithKeyTest.class,
-        KeyringTest.signWithKeysTest.class,
-        KeyringTest.signMessageTest.class,
-        KeyringTest.recoverTest.class,
-        KeyringTest.decryptTest.class,
-        KeyringTest.encryptTest.class,
-        KeyringTest.encryptV3Test.class,
-        KeyringTest.getKeyByRoleTest.class,
-        KeyringTest.getKlaytnWalletKeyTest.class,
-        KeyringTest.getPublicKeyTest.class,
-        KeyringTest.isDecoupledTest.class,
-        KeyringTest.toAccountTest.class,
-})
 public class KeyringTest {
 
     public static void checkValidateSingleKey(SingleKeyring actualKeyring, String expectedAddress, String expectedPrivateKey) {

--- a/core/src/test/java/com/klaytn/caver/common/RpcTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/RpcTest.java
@@ -54,17 +54,6 @@ import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses(
-        {
-                RpcTest.encodeAccountKeyTest.class,
-                RpcTest.decodeAccountKeyTest.class,
-                RpcTest.sendTransactionAsFeePayerTest.class,
-                RpcTest.signTransactionTest.class,
-                RpcTest.signTransactionAsFeePayerTest.class,
-                RpcTest.otherRPCTest.class
-        }
-)
 public class RpcTest extends Accounts {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static Klay klay = caver.rpc.klay;

--- a/core/src/test/java/com/klaytn/caver/common/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/UtilsTest.java
@@ -17,23 +17,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        UtilsTest.isAddressTest.class,
-        UtilsTest.isValidPrivateKeyTest.class,
-        UtilsTest.isKlaytnWalletKeyTest.class,
-        UtilsTest.isValidPublicKeyTest.class,
-        UtilsTest.decompressPublicKeyTest.class,
-        UtilsTest.compressedPublicKeyTest.class,
-        UtilsTest.hashMessageTest.class,
-        UtilsTest.parseKlaytnWalletKeyTest.class,
-        UtilsTest.isHexTest.class,
-        UtilsTest.isHexStrictTest.class,
-        UtilsTest.addHexPrefixTest.class,
-        UtilsTest.stripHexPrefixTest.class,
-        UtilsTest.convertToPebTest.class,
-        UtilsTest.convertFromPebTest.class
-})
 public class UtilsTest {
 
     public static class isAddressTest {

--- a/core/src/test/java/com/klaytn/caver/common/transaction/AccountUpdateTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/AccountUpdateTest.java
@@ -27,20 +27,6 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        AccountUpdateTest.createInstance.class,
-        AccountUpdateTest.createInstanceBuilder.class,
-        AccountUpdateTest.getRLPEncodingTest.class,
-        AccountUpdateTest.signWithKeyTest.class,
-        AccountUpdateTest.signWithKeysTest.class,
-        AccountUpdateTest.appendSignaturesTest.class,
-        AccountUpdateTest.combineSignatureTest.class,
-        AccountUpdateTest.getRawTransactionTest.class,
-        AccountUpdateTest.getTransactionHashTest.class,
-        AccountUpdateTest.getSenderTxHashTest.class,
-        AccountUpdateTest.getRLPEncodingForSignatureTest.class,
-})
 public class AccountUpdateTest {
 
     public static AbstractKeyring generateRoleBaseKeyring(int[] numArr, String address) {

--- a/core/src/test/java/com/klaytn/caver/common/transaction/CancelTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/CancelTest.java
@@ -24,20 +24,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        CancelTest.createInstance.class,
-        CancelTest.createInstanceBuilder.class,
-        CancelTest.getRLPEncodingTest.class,
-        CancelTest.signWithKeyTest.class,
-        CancelTest.signWithKeysTest.class,
-        CancelTest.appendSignaturesTest.class,
-        CancelTest.combineSignatureTest.class,
-        CancelTest.getRawTransactionTest.class,
-        CancelTest.getTransactionHashTest.class,
-        CancelTest.getSenderTxHashTest.class,
-        CancelTest.getRLPEncodingForSignatureTest.class,
-})
 public class CancelTest {
 
     static Caver caver = new Caver(Caver.DEFAULT_URL);

--- a/core/src/test/java/com/klaytn/caver/common/transaction/ChainDataAnchoringTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/ChainDataAnchoringTest.java
@@ -24,20 +24,6 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        ChainDataAnchoringTest.createInstance.class,
-        ChainDataAnchoringTest.createInstanceBuilder.class,
-        ChainDataAnchoringTest.getRLPEncodingTest.class,
-        ChainDataAnchoringTest.signTest.class,
-        ChainDataAnchoringTest.signWithKeysTest.class,
-        ChainDataAnchoringTest.appendSignaturesTest.class,
-        ChainDataAnchoringTest.combineSignatureTest.class,
-        ChainDataAnchoringTest.getRawTransactionTest.class,
-        ChainDataAnchoringTest.getTransactionHashTest.class,
-        ChainDataAnchoringTest.getSenderTxHashTest.class,
-        ChainDataAnchoringTest.getRLPEncodingForSignatureTest.class,
-})
 public class ChainDataAnchoringTest {
 
     static Caver caver = new Caver(Caver.DEFAULT_URL);

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateTest.java
@@ -22,20 +22,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedAccountUpdateTest.createInstance.class,
-        FeeDelegatedAccountUpdateTest.createInstanceBuilder.class,
-        FeeDelegatedAccountUpdateTest.getRLPEncodingTest.class,
-        FeeDelegatedAccountUpdateTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedAccountUpdateTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedAccountUpdateTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedAccountUpdateTest.combineSignatureTest.class,
-        FeeDelegatedAccountUpdateTest.getRawTransactionTest.class,
-        FeeDelegatedAccountUpdateTest.getTransactionHashTest.class,
-        FeeDelegatedAccountUpdateTest.getSenderTxHashTest.class,
-        FeeDelegatedAccountUpdateTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedAccountUpdateTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateWithRatioTest.java
@@ -22,20 +22,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedAccountUpdateWithRatioTest.createInstance.class,
-        FeeDelegatedAccountUpdateWithRatioTest.createInstanceBuilder.class,
-        FeeDelegatedAccountUpdateWithRatioTest.getRLPEncodingTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.combineSignatureTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.getRawTransactionTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.getTransactionHashTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.getSenderTxHashTest.class,
-        FeeDelegatedAccountUpdateWithRatioTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
+
 public class FeeDelegatedAccountUpdateWithRatioTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelTest.java
@@ -21,20 +21,7 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedCancelTest.createInstance.class,
-        FeeDelegatedCancelTest.createInstanceBuilder.class,
-        FeeDelegatedCancelTest.getRLPEncodingTest.class,
-        FeeDelegatedCancelTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedCancelTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedCancelTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedCancelTest.combineSignatureTest.class,
-        FeeDelegatedCancelTest.getRawTransactionTest.class,
-        FeeDelegatedCancelTest.getTransactionHashTest.class,
-        FeeDelegatedCancelTest.getSenderTxHashTest.class,
-        FeeDelegatedCancelTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
+
 public class FeeDelegatedCancelTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String senderPrivateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelWithRatioTest.java
@@ -21,20 +21,7 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedCancelWithRatioTest.createInstance.class,
-        FeeDelegatedCancelWithRatioTest.createInstanceBuilder.class,
-        FeeDelegatedCancelWithRatioTest.getRLPEncodingTest.class,
-        FeeDelegatedCancelWithRatioTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedCancelWithRatioTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedCancelWithRatioTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedCancelWithRatioTest.combineSignatureTest.class,
-        FeeDelegatedCancelWithRatioTest.getRawTransactionTest.class,
-        FeeDelegatedCancelWithRatioTest.getTransactionHashTest.class,
-        FeeDelegatedCancelWithRatioTest.getSenderTxHashTest.class,
-        FeeDelegatedCancelWithRatioTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
+
 public class FeeDelegatedCancelWithRatioTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String senderPrivateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringTest.java
@@ -20,20 +20,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedChainDataAnchoringTest.createInstance.class,
-        FeeDelegatedChainDataAnchoringTest.createInstanceBuilder.class,
-        FeeDelegatedChainDataAnchoringTest.getRLPEncodingTest.class,
-        FeeDelegatedChainDataAnchoringTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedChainDataAnchoringTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedChainDataAnchoringTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedChainDataAnchoringTest.combineSignatureTest.class,
-        FeeDelegatedChainDataAnchoringTest.getRawTransactionTest.class,
-        FeeDelegatedChainDataAnchoringTest.getTransactionHashTest.class,
-        FeeDelegatedChainDataAnchoringTest.getSenderTxHashTest.class,
-        FeeDelegatedChainDataAnchoringTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedChainDataAnchoringTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringWithRatioTest.java
@@ -20,20 +20,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedChainDataAnchoringWithRatioTest.createInstance.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.createInstanceBuilder.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.getRLPEncodingTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.combineSignatureTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.getRawTransactionTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.getTransactionHashTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.getSenderTxHashTest.class,
-        FeeDelegatedChainDataAnchoringWithRatioTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedChainDataAnchoringWithRatioTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String senderPrivateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployTest.java
@@ -21,20 +21,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedSmartContractDeployTest.createInstance.class,
-        FeeDelegatedSmartContractDeployTest.createInstanceBuilder.class,
-        FeeDelegatedSmartContractDeployTest.getRLPEncodingTest.class,
-        FeeDelegatedSmartContractDeployTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedSmartContractDeployTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedSmartContractDeployTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedSmartContractDeployTest.combineSignatureTest.class,
-        FeeDelegatedSmartContractDeployTest.getRawTransactionTest.class,
-        FeeDelegatedSmartContractDeployTest.getTransactionHashTest.class,
-        FeeDelegatedSmartContractDeployTest.getSenderTxHashTest.class,
-        FeeDelegatedSmartContractDeployTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedSmartContractDeployTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployWithRatioTest.java
@@ -22,20 +22,7 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedSmartContractDeployWithRatioTest.createInstance.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.createInstanceBuilder.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.getRLPEncodingTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.combineSignatureTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.getRawTransactionTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.getTransactionHashTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.getSenderTxHashTest.class,
-        FeeDelegatedSmartContractDeployWithRatioTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
+
 public class FeeDelegatedSmartContractDeployWithRatioTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionTest.java
@@ -19,20 +19,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedSmartContractExecutionTest.createInstance.class,
-        FeeDelegatedSmartContractExecutionTest.createInstanceBuilder.class,
-        FeeDelegatedSmartContractExecutionTest.getRLPEncodingTest.class,
-        FeeDelegatedSmartContractExecutionTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedSmartContractExecutionTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedSmartContractExecutionTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedSmartContractExecutionTest.combineSignatureTest.class,
-        FeeDelegatedSmartContractExecutionTest.getRawTransactionTest.class,
-        FeeDelegatedSmartContractExecutionTest.getTransactionHashTest.class,
-        FeeDelegatedSmartContractExecutionTest.getSenderTxHashTest.class,
-        FeeDelegatedSmartContractExecutionTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedSmartContractExecutionTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionWithRatioTest.java
@@ -22,20 +22,6 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedSmartContractExecutionWithRatioTest.createInstance.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.createInstanceBuilder.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.getRLPEncodingTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.combineSignatureTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.getRawTransactionTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.getTransactionHashTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.getSenderTxHashTest.class,
-        FeeDelegatedSmartContractExecutionWithRatioTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedSmartContractExecutionWithRatioTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoTest.java
@@ -21,20 +21,6 @@ import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedValueTransferMemoTest.createInstance.class,
-        FeeDelegatedValueTransferMemoTest.createInstanceBuilder.class,
-        FeeDelegatedValueTransferMemoTest.getRLPEncodingTest.class,
-        FeeDelegatedValueTransferMemoTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedValueTransferMemoTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedValueTransferMemoTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedValueTransferMemoTest.combineSignatureTest.class,
-        FeeDelegatedValueTransferMemoTest.getRawTransactionTest.class,
-        FeeDelegatedValueTransferMemoTest.getTransactionHashTest.class,
-        FeeDelegatedValueTransferMemoTest.getSenderTxHashTest.class,
-        FeeDelegatedValueTransferMemoTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedValueTransferMemoTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
     static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoWithRatioTest.java
@@ -21,20 +21,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedValueTransferMemoWithRatioTest.createInstance.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.createInstanceBuilder.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.getRLPEncodingTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.combineSignatureTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.getRawTransactionTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.getTransactionHashTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.getSenderTxHashTest.class,
-        FeeDelegatedValueTransferMemoWithRatioTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedValueTransferMemoWithRatioTest {
 
     static Caver caver = new Caver(Caver.DEFAULT_URL);

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferTest.java
@@ -20,20 +20,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedValueTransferTest.createInstance.class,
-        FeeDelegatedValueTransferTest.createInstanceBuilder.class,
-        FeeDelegatedValueTransferTest.getRLPEncodingTest.class,
-        FeeDelegatedValueTransferTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedValueTransferTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedValueTransferTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedValueTransferTest.combineSignatureTest.class,
-        FeeDelegatedValueTransferTest.getRawTransactionTest.class,
-        FeeDelegatedValueTransferTest.getTransactionHashTest.class,
-        FeeDelegatedValueTransferTest.getSenderTxHashTest.class,
-        FeeDelegatedValueTransferTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedValueTransferTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferWithRatioTest.java
@@ -21,21 +21,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        FeeDelegatedValueTransferWithRatioTest.createInstance.class,
-        FeeDelegatedValueTransferWithRatioTest.createInstanceBuilder.class,
-        FeeDelegatedValueTransferWithRatioTest.getRLPEncodingTest.class,
-        FeeDelegatedValueTransferWithRatioTest.signAsFeePayer_OneKeyTest.class,
-        FeeDelegatedValueTransferWithRatioTest.signAsFeePayer_AllKeyTest.class,
-        FeeDelegatedValueTransferWithRatioTest.appendFeePayerSignaturesTest.class,
-        FeeDelegatedValueTransferWithRatioTest.combineSignatureTest.class,
-        FeeDelegatedValueTransferWithRatioTest.getRawTransactionTest.class,
-        FeeDelegatedValueTransferWithRatioTest.getTransactionHashTest.class,
-        FeeDelegatedValueTransferWithRatioTest.getSenderTxHashTest.class,
-        FeeDelegatedValueTransferWithRatioTest.getRLPEncodingForFeePayerSignatureTest.class,
-})
 public class FeeDelegatedValueTransferWithRatioTest {
     static Caver caver = new Caver(Caver.DEFAULT_URL);
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/LegacyTransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/LegacyTransactionTest.java
@@ -25,20 +25,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        LegacyTransactionTest.createInstance.class,
-        LegacyTransactionTest.createInstanceBuilder.class,
-        LegacyTransactionTest.signWithKeyTest.class,
-        LegacyTransactionTest.signWithKeysTest.class,
-        LegacyTransactionTest.getRLPEncodingTest.class,
-        LegacyTransactionTest.combineSignatureTest.class,
-        LegacyTransactionTest.getRawTransactionTest.class,
-        LegacyTransactionTest.getTransactionHashTest.class,
-        LegacyTransactionTest.getSenderTxHashTest.class,
-        LegacyTransactionTest.getRLPEncodingForSignatureTest.class,
-        LegacyTransactionTest.appendSignaturesTest.class
-})
 public class LegacyTransactionTest {
 
     public static class createInstance {

--- a/core/src/test/java/com/klaytn/caver/common/transaction/SmartContractDeployTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/SmartContractDeployTest.java
@@ -25,21 +25,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertNotNull;
 
-
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        SmartContractDeployTest.createInstance.class,
-        SmartContractDeployTest.createInstanceBuilder.class,
-        SmartContractDeployTest.getRLPEncodingTest.class,
-        SmartContractDeployTest.signWithKeyTest.class,
-        SmartContractDeployTest.signWithKeysTest.class,
-        SmartContractDeployTest.appendSignaturesTest.class,
-        SmartContractDeployTest.combineSignatureTest.class,
-        SmartContractDeployTest.getRawTransactionTest.class,
-        SmartContractDeployTest.getTransactionHashTest.class,
-        SmartContractDeployTest.getSenderTxHashTest.class,
-        SmartContractDeployTest.getRLPEncodingForSignatureTest.class,
-})
 public class SmartContractDeployTest {
 
     public static final String BYTECODE = "0x60806040526000805534801561001457600080fd5b506101ea806100246000396000f30060806040526004361061006d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306661abd1461007257806342cbb15c1461009d578063767800de146100c8578063b22636271461011f578063d14e62b814610150575b600080fd5b34801561007e57600080fd5b5061008761017d565b6040518082815260200191505060405180910390f35b3480156100a957600080fd5b506100b2610183565b6040518082815260200191505060405180910390f35b3480156100d457600080fd5b506100dd61018b565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b34801561012b57600080fd5b5061014e60048036038101908080356000191690602001909291905050506101b1565b005b34801561015c57600080fd5b5061017b600480360381019080803590602001909291905050506101b4565b005b60005481565b600043905090565b600160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b50565b80600081905550505600a165627a7a7230582053c65686a3571c517e2cf4f741d842e5ee6aa665c96ce70f46f9a594794f11eb0029";

--- a/core/src/test/java/com/klaytn/caver/common/transaction/SmartContractExecutionTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/SmartContractExecutionTest.java
@@ -20,21 +20,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        SmartContractExecutionTest.createInstance.class,
-        SmartContractExecutionTest.createInstanceBuilder.class,
-        SmartContractExecutionTest.getRLPEncodingTest.class,
-        SmartContractExecutionTest.signWithKeyTest.class,
-        SmartContractExecutionTest.signWithKeysTest.class,
-        SmartContractExecutionTest.appendSignaturesTest.class,
-        SmartContractExecutionTest.combineSignatureTest.class,
-        SmartContractExecutionTest.getRawTransactionTest.class,
-        SmartContractExecutionTest.getTransactionHashTest.class,
-        SmartContractExecutionTest.getSenderTxHashTest.class,
-        SmartContractExecutionTest.getRLPEncodingForSignatureTest.class,
-})
 public class SmartContractExecutionTest {
 
     static Caver caver = new Caver(Caver.DEFAULT_URL);

--- a/core/src/test/java/com/klaytn/caver/common/transaction/ValueTransferMemoTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/ValueTransferMemoTest.java
@@ -23,21 +23,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        ValueTransferMemoTest.createInstance.class,
-        ValueTransferMemoTest.createInstanceBuilder.class,
-        ValueTransferMemoTest.getRLPEncodingTest.class,
-        ValueTransferMemoTest.signWithKeyTest.class,
-        ValueTransferMemoTest.signWithKeysTest.class,
-        ValueTransferMemoTest.appendSignaturesTest.class,
-        ValueTransferMemoTest.combineSignatureTest.class,
-        ValueTransferMemoTest.getRawTransactionTest.class,
-        ValueTransferMemoTest.getTransactionHashTest.class,
-        ValueTransferMemoTest.getSenderTxHashTest.class,
-        ValueTransferMemoTest.getRLPEncodingForSignatureTest.class,
-})
 public class ValueTransferMemoTest {
 
     static Caver caver = new Caver(Caver.DEFAULT_URL);

--- a/core/src/test/java/com/klaytn/caver/common/transaction/ValueTransferTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/ValueTransferTest.java
@@ -23,20 +23,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-        ValueTransferTest.createInstance.class,
-        ValueTransferTest.createInstanceBuilder.class,
-        ValueTransferTest.getRLPEncodingTest.class,
-        ValueTransferTest.signWithKeyTest.class,
-        ValueTransferTest.signWithKeysTest.class,
-        ValueTransferTest.appendSignaturesTest.class,
-        ValueTransferTest.combineSignatureTest.class,
-        ValueTransferTest.getRawTransactionTest.class,
-        ValueTransferTest.getTransactionHashTest.class,
-        ValueTransferTest.getSenderTxHashTest.class,
-        ValueTransferTest.getRLPEncodingForSignatureTest.class,
-})
 public class ValueTransferTest {
 
     public static AbstractKeyring generateRoleBaseKeyring(int[] numArr, String address) {


### PR DESCRIPTION
## Proposed changes

This PR reduces caver-java test time.
  - remove jUnit suite annotation. It operates test case twice.
  - This PR saved 10min in the test (current 26min / PR 16min)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
