### PR TITLE
Remove dependency of Caver class from Contract class 

### DIFF
--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -20,10 +20,12 @@ import com.klaytn.caver.Caver;
 import com.klaytn.caver.contract.Contract;
 import com.klaytn.caver.contract.ContractDeployParams;
 import com.klaytn.caver.contract.SendOptions;
+import com.klaytn.caver.kct.kip7.KIP7ConstantData;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.rpc.RPC;
+import com.klaytn.caver.wallet.IWallet;
 import org.web3j.abi.datatypes.Type;
-import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.utils.Numeric;
 
 import java.io.IOException;
@@ -69,7 +71,17 @@ public class KIP17 extends Contract {
      * @throws IOException
      */
     public KIP17(Caver caver) throws IOException {
-        super(caver, KIP17ConstantData.ABI);
+        this(caver, null);
+    }
+
+    /**
+     * Creates a KIP17 instance
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @throws IOException
+     */
+    public KIP17(IWallet wallet, RPC rpc) throws IOException {
+        this(wallet, rpc, null);
     }
 
     /**
@@ -79,12 +91,23 @@ public class KIP17 extends Contract {
      * @throws IOException
      */
     public KIP17(Caver caver, String contractAddress) throws IOException {
-        super(caver, KIP17ConstantData.ABI, contractAddress);
+        this(caver.getWallet(), caver.getRpc(), contractAddress);
+    }
+
+    /**
+     * Creates a KIP17 instance
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @param contractAddress A contract address
+     * @throws IOException
+     */
+    public KIP17(IWallet wallet, RPC rpc, String contractAddress) throws IOException {
+        super(wallet, rpc, KIP17ConstantData.ABI, contractAddress);
     }
 
     /**
      * Deploy a KIP-17 contract.
-     * It must add deployer's keyring in caver.wallet.
+     * It must add deployer's key data in caver.wallet.
      * @param caver A Caver instance.
      * @param deployer A deployer's address.
      * @param name A KIP-17 contract name
@@ -98,8 +121,24 @@ public class KIP17 extends Contract {
     }
 
     /**
+     * Deploy a KIP-17 contract.
+     * It must add deployer's key data in wallet.
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @param deployer A deployer's address.
+     * @param name A KIP-17 contract name
+     * @param symbol A KIP-17 contract symbol
+     * @return KIP17
+     * @throws Exception
+     */
+    public static KIP17 deploy(IWallet wallet, RPC rpc, String deployer, String name, String symbol) throws Exception {
+        KIP17DeployParams deployParams = new KIP17DeployParams(name, symbol);
+        return deploy(wallet, rpc, deployParams, deployer);
+    }
+
+    /**
      * Deploy KIP17 contract
-     * It must add deployer's keyring in caver.wallet.
+     * It must add deployer's key data in caver.wallet.
      * @param caver A Caver instance.
      * @param tokenInfo The KIP-17 contract's deploy parameter values.
      * @param deployer A deployer's address.
@@ -107,11 +146,24 @@ public class KIP17 extends Contract {
      * @throws Exception
      */
     public static KIP17 deploy(Caver caver, KIP17DeployParams tokenInfo, String deployer) throws Exception {
+        return deploy(caver.getWallet(), caver.getRpc(), tokenInfo, deployer);
+    }
+
+    /**
+     * Deploy KIP17 contract
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @param tokenInfo The KIP-17 contract's deploy parameter values.
+     * @param deployer A deployer's address.
+     * @return KIP17
+     * @throws Exception
+     */
+    public static KIP17 deploy(IWallet wallet, RPC rpc, KIP17DeployParams tokenInfo, String deployer) throws Exception {
         List deployArgument = Arrays.asList(tokenInfo.getName(), tokenInfo.getSymbol());
         ContractDeployParams contractDeployParams = new ContractDeployParams(KIP17ConstantData.BINARY, deployArgument);
         SendOptions sendOptions = new SendOptions(deployer, BigInteger.valueOf(6500000));
 
-        KIP17 kip17 = new KIP17(caver);
+        KIP17 kip17 = new KIP17(wallet, rpc);
         kip17.deploy(contractDeployParams, sendOptions);
 
         return kip17;
@@ -123,7 +175,7 @@ public class KIP17 extends Contract {
      */
     public KIP17 clone() {
         try {
-            return new KIP17(this.getCaver());
+            return new KIP17(this.getWallet(), this.getRpc());
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -138,7 +190,7 @@ public class KIP17 extends Contract {
      */
     public KIP17 clone(String tokenAddress) {
         try {
-            return new KIP17(this.getCaver(), tokenAddress);
+            return new KIP17(this.getWallet(), this.getRpc(), tokenAddress);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
@@ -22,8 +22,9 @@ import com.klaytn.caver.contract.ContractDeployParams;
 import com.klaytn.caver.contract.SendOptions;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.rpc.RPC;
+import com.klaytn.caver.wallet.IWallet;
 import org.web3j.abi.datatypes.Type;
-import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.utils.Numeric;
 
 import java.io.IOException;
@@ -66,7 +67,17 @@ public class KIP7 extends Contract {
      * @throws IOException
      */
     public KIP7(Caver caver) throws IOException {
-        super(caver, KIP7ConstantData.ABI);
+        this(caver.getWallet(), caver.getRpc());
+    }
+
+    /**
+     * Creates a KIP7 instance.
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @throws IOException
+     */
+    public KIP7(IWallet wallet, RPC rpc) throws IOException {
+        this(wallet, rpc, null);
     }
 
     /**
@@ -76,12 +87,23 @@ public class KIP7 extends Contract {
      * @throws IOException
      */
     public KIP7(Caver caver, String contractAddress) throws IOException {
-        super(caver, KIP7ConstantData.ABI, contractAddress);
+        this(caver.getWallet(), caver.getRpc(), contractAddress);
+    }
+
+    /**
+     * Creates a KIP7 instance
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @param contractAddress A contract address
+     * @throws IOException
+     */
+    public KIP7(IWallet wallet, RPC rpc, String contractAddress) throws IOException {
+        super(wallet, rpc, KIP7ConstantData.ABI, contractAddress);
     }
 
     /**
      * Deploy KIP-7 contract.
-     * It must add deployer's keyring in caver.wallet.
+     * It must add deployer's key data in caver.wallet.
      * @param caver A Caver instance.
      * @param deployer A deployer's address.
      * @param name A KIP-7 contract name.
@@ -92,8 +114,25 @@ public class KIP7 extends Contract {
      * @throws Exception
      */
     public static KIP7 deploy(Caver caver, String deployer, String name, String symbol, int decimals, BigInteger initialSupply) throws Exception {
+        return deploy(caver.getWallet(), caver.getRpc(), deployer, name, symbol, decimals, initialSupply);
+    }
+
+    /**
+     * Deploy KIP-7 contract.
+     * It must add deployer's key data in wallet.
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @param deployer A deployer's address.
+     * @param name A KIP-7 contract name.
+     * @param symbol A KIP-7 contract symbol.
+     * @param decimals A KIP-7 contract decimals.
+     * @param initialSupply A KIP-7 contract initial supply.
+     * @return KIP7
+     * @throws Exception
+     */
+    public static KIP7 deploy(IWallet wallet, RPC rpc, String deployer, String name, String symbol, int decimals, BigInteger initialSupply) throws Exception {
         KIP7DeployParams params = new KIP7DeployParams(name, symbol, decimals, initialSupply);
-        return deploy(caver, params, deployer);
+        return deploy(wallet, rpc, params, deployer);
     }
 
     /**
@@ -106,11 +145,25 @@ public class KIP7 extends Contract {
      * @throws Exception
      */
     public static KIP7 deploy(Caver caver, KIP7DeployParams tokenInfo, String deployer) throws Exception {
+        return deploy(caver.getWallet(), caver.getRpc(), tokenInfo, deployer);
+    }
+
+    /**
+     * Deploy KIP-7 contract.
+     * It must add deployer's key data in wallet.
+     * @param wallet A Class instance implemented IWallet.
+     * @param rpc A RPC instance to call klaytn JSON/RPC API.
+     * @param tokenInfo The KIP-7 contract's deploy parameter values
+     * @param deployer A deployer's address
+     * @return KIP7
+     * @throws Exception
+     */
+    public static KIP7 deploy(IWallet wallet, RPC rpc, KIP7DeployParams tokenInfo, String deployer) throws Exception {
         List deployArgument = Arrays.asList(tokenInfo.getName(), tokenInfo.getSymbol(), tokenInfo.getDecimals(), tokenInfo.getInitialSupply());
         ContractDeployParams contractDeployParams = new ContractDeployParams(KIP7ConstantData.BINARY, deployArgument);
         SendOptions sendOptions = new SendOptions(deployer, BigInteger.valueOf(4000000));
 
-        KIP7 kip7 = new KIP7(caver);
+        KIP7 kip7 = new KIP7(wallet, rpc);
         kip7.deploy(contractDeployParams, sendOptions);
 
         return kip7;
@@ -123,7 +176,7 @@ public class KIP7 extends Contract {
     @Override
     public KIP7 clone() {
         try {
-            return new KIP7(this.getCaver());
+            return new KIP7(this.getWallet(), this.getRpc());
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -137,7 +190,7 @@ public class KIP7 extends Contract {
      */
     public KIP7 clone(String tokenAddress) {
         try {
-            return new KIP7(this.getCaver(), tokenAddress);
+            return new KIP7(this.getWallet(), this.getRpc(), tokenAddress);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/core/src/main/java/com/klaytn/caver/transaction/response/PollingTransactionReceiptProcessor.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/response/PollingTransactionReceiptProcessor.java
@@ -18,6 +18,7 @@ package com.klaytn.caver.transaction.response;
 
 import com.klaytn.caver.Caver;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.rpc.RPC;
 import org.web3j.protocol.exceptions.TransactionException;
 
 import java.io.IOException;
@@ -32,6 +33,12 @@ public class PollingTransactionReceiptProcessor extends TransactionReceiptProces
 
     public PollingTransactionReceiptProcessor(Caver caver, long sleepDuration, int attempts) {
         super(caver);
+        this.sleepDuration = sleepDuration;
+        this.attempts = attempts;
+    }
+
+    public PollingTransactionReceiptProcessor(RPC rpc, long sleepDuration, int attempts) {
+        super(rpc);
         this.sleepDuration = sleepDuration;
         this.attempts = attempts;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/response/QueuingTransactionReceiptProcessor.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/response/QueuingTransactionReceiptProcessor.java
@@ -20,6 +20,7 @@ import com.klaytn.caver.Caver;
 import com.klaytn.caver.methods.response.Callback;
 import com.klaytn.caver.methods.response.KlayTransactionReceipt;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.rpc.RPC;
 import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.utils.Async;
 
@@ -46,9 +47,9 @@ public class QueuingTransactionReceiptProcessor extends TransactionReceiptProces
     private final BlockingQueue<RequestWrapper> pendingTransactions;
 
     public QueuingTransactionReceiptProcessor(
-            Caver caver, Callback callback,
+            RPC rpc, Callback callback,
             int pollingAttemptsPerTxHash, long pollingFrequency) {
-        super(caver);
+        super(rpc);
         this.scheduledExecutorService = Async.defaultExecutorService();
         this.callback = callback;
         this.pendingTransactions = new LinkedBlockingQueue<>();
@@ -61,7 +62,12 @@ public class QueuingTransactionReceiptProcessor extends TransactionReceiptProces
 
     public QueuingTransactionReceiptProcessor(
             Caver caver, Callback callback) {
-        this(caver, callback, DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH, DEFAULT_POLLING_FREQUENCY);
+        this(caver.getRpc(), callback, DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH, DEFAULT_POLLING_FREQUENCY);
+    }
+
+    public QueuingTransactionReceiptProcessor(
+            RPC rpc, Callback callback) {
+        this(rpc, callback, DEFAULT_POLLING_ATTEMPTS_PER_TX_HASH, DEFAULT_POLLING_FREQUENCY);
     }
 
     @Override

--- a/core/src/main/java/com/klaytn/caver/transaction/response/TransactionReceiptProcessor.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/response/TransactionReceiptProcessor.java
@@ -18,6 +18,7 @@ package com.klaytn.caver.transaction.response;
 
 import com.klaytn.caver.Caver;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.rpc.RPC;
 import org.web3j.protocol.exceptions.TransactionException;
 
 import java.io.IOException;
@@ -27,17 +28,21 @@ import java.util.Optional;
  * Abstraction for managing how we wait for transaction receipts to be generated on the network.
  */
 public abstract class TransactionReceiptProcessor {
-    private final Caver caver;
+    private final RPC rpc;
 
     public TransactionReceiptProcessor(Caver caver) {
-        this.caver = caver;
+        this(caver.getRpc());
+    }
+
+    public TransactionReceiptProcessor(RPC rpc) {
+        this.rpc = rpc;
     }
 
     public abstract TransactionReceipt.TransactionReceiptData waitForTransactionReceipt(String transactionHash)
             throws IOException, TransactionException;
 
     Optional<TransactionReceipt.TransactionReceiptData> sendTransactionReceiptRequest(String transactionHash) throws IOException, TransactionException{
-        TransactionReceipt transactionReceipt = caver.rpc.klay.getTransactionReceipt(transactionHash).send();
+        TransactionReceipt transactionReceipt = rpc.klay.getTransactionReceipt(transactionHash).send();
         if(transactionReceipt.hasError()) {
             throw new TransactionException("Error processing request: "
                     + transactionReceipt.getError().getMessage());


### PR DESCRIPTION
## Proposed changes

This PR remove dependency of Caver class from Contract class.
  - Caver instance's wallet and rpc variable no longer perform part of the contract's operation.(signing, call klaytn api).
  - User can set IWallet and RPC instance to perform singing and call klaytn api.
  - `Contract` can set a `IWallet` instance through `Contract@setWallet`.
  - `Contract` can set a `RPC` instance through `Contract@setRPC`.
     - add a constructor that receives a RPC instance as a parameter in TransactionReceiptProcessor
     - add a constructor that receives a IWallet, RPC instance as a parameter in Contract
     - add a constructor and methods that receives a IWallet, RPC instance as ap parameter in KIP7, KIP17

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
