### PR TITLE
support Contract@setWallet()

### DIFF
--- a/core/src/main/java/com/klaytn/caver/contract/Contract.java
+++ b/core/src/main/java/com/klaytn/caver/contract/Contract.java
@@ -538,6 +538,10 @@ public class Contract {
         return defaultSendOptions;
     }
 
+    /**
+     * Getter function for wallet
+     * @return IWallet
+     */
     public IWallet getWallet() {
         return wallet;
     }
@@ -604,6 +608,10 @@ public class Contract {
         this.constructor = constructor;
     }
 
+    /**
+     * Setter function for wallet
+     * @param wallet The class instance implemented IWallet to sign transaction.
+     */
     public void setWallet(IWallet wallet) {
         this.wallet = wallet;
 

--- a/core/src/main/java/com/klaytn/caver/contract/Contract.java
+++ b/core/src/main/java/com/klaytn/caver/contract/Contract.java
@@ -29,6 +29,7 @@ import com.klaytn.caver.transaction.response.PollingTransactionReceiptProcessor;
 import com.klaytn.caver.transaction.response.TransactionReceiptProcessor;
 import com.klaytn.caver.transaction.type.SmartContractDeploy;
 import com.klaytn.caver.utils.CodeFormat;
+import com.klaytn.caver.wallet.IWallet;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
@@ -82,6 +83,11 @@ public class Contract {
      */
     SendOptions defaultSendOptions;
 
+    /**
+     * The class instance implemented IWallet to sign transaction.
+     */
+    IWallet wallet;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Contract.class);
 
     /**
@@ -106,6 +112,7 @@ public class Contract {
         setCaver(caver);
         setContractAddress(contractAddress);
         setDefaultSendOptions(new SendOptions());
+        setWallet(caver.getWallet());
     }
 
     /**
@@ -167,7 +174,7 @@ public class Contract {
                 .setGas(sendOptions.getGas())
                 .build();
 
-        caver.getWallet().sign(sendOptions.getFrom(), smartContractDeploy);
+        this.wallet.sign(sendOptions.getFrom(), smartContractDeploy);
 
         Bytes32 txHash = caver.rpc.klay.sendRawTransaction(smartContractDeploy.getRawTransaction()).send();
         TransactionReceipt.TransactionReceiptData receipt = processor.waitForTransactionReceipt(txHash.getResult());
@@ -531,6 +538,10 @@ public class Contract {
         return defaultSendOptions;
     }
 
+    public IWallet getWallet() {
+        return wallet;
+    }
+
     /**
      * Setter function for Caver.
      * @param caver The Caver instance.
@@ -591,6 +602,14 @@ public class Contract {
      */
     void setConstructor(ContractMethod constructor) {
         this.constructor = constructor;
+    }
+
+    public void setWallet(IWallet wallet) {
+        this.wallet = wallet;
+
+        if(this.methods != null && this.methods.size() != 0) {
+            this.getMethods().values().forEach(value -> value.setWallet(this.wallet));
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractMethod.java
@@ -27,6 +27,7 @@ import com.klaytn.caver.transaction.response.PollingTransactionReceiptProcessor;
 import com.klaytn.caver.transaction.response.TransactionReceiptProcessor;
 import com.klaytn.caver.transaction.type.SmartContractExecution;
 import com.klaytn.caver.utils.Utils;
+import com.klaytn.caver.wallet.IWallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.web3j.abi.datatypes.Type;
@@ -81,6 +82,11 @@ public class ContractMethod {
      * The default send option. When you execute call() or send() without SendOptions, defaultSendOptions will be used.
      */
     SendOptions defaultSendOptions;
+
+    /**
+     * The class instance implemented IWallet interface to sign transaction.
+     */
+    IWallet wallet;
 
 
     List<ContractMethod> nextContractMethods = new ArrayList<>();
@@ -505,6 +511,14 @@ public class ContractMethod {
         this.defaultSendOptions = defaultSendOptions;
     }
 
+    /**
+     * Setter function for wallet
+     * @param wallet The class instance implemented IWallet interface to sign transaction.
+     */
+    public void setWallet(IWallet wallet) {
+        this.wallet = wallet;
+    }
+
     void setNextContractMethods(List<ContractMethod> nextContractMethods) {
         this.nextContractMethods = nextContractMethods;
     }
@@ -629,7 +643,7 @@ public class ContractMethod {
                 .setValue(sendOptions.getValue())
                 .build();
 
-        caver.getWallet().sign(sendOptions.getFrom(), smartContractExecution);
+        this.wallet.sign(sendOptions.getFrom(), smartContractExecution);
         Bytes32 txHash = caver.rpc.klay.sendRawTransaction(smartContractExecution).send();
 
         TransactionReceipt.TransactionReceiptData receipt = processor.waitForTransactionReceipt(txHash.getResult());

--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -98,6 +98,17 @@ public class KIP17 extends Contract {
         return deploy(caver, deployParams, deployer);
     }
 
+    /**
+     * Deploy a KIP-17 contract.
+     * The wallet used in the contract is set to the wallet type passed as a parameter of the method.
+     * @param caver A Caver instance.
+     * @param deployer A deployer's address.
+     * @param name A KIP-17 contract name
+     * @param symbol A KIP-17 contract symbol
+     * @param wallet The class instance implemented IWallet to sign transaction.
+     * @return KIP17
+     * @throws Exception
+     */
     public static KIP17 deploy(Caver caver, String deployer, String name, String symbol, IWallet wallet) throws Exception {
         KIP17DeployParams deployParams = new KIP17DeployParams(name, symbol);
         return deploy(caver, deployParams, deployer, wallet);
@@ -116,6 +127,16 @@ public class KIP17 extends Contract {
         return deploy(caver, tokenInfo, deployer, caver.getWallet());
     }
 
+    /**
+     * Deploy KIP17 contract
+     * The wallet used in the contract is set to the wallet type passed as a parameter of the method.
+     * @param caver A Caver instance.
+     * @param tokenInfo The KIP-17 contract's deploy parameter values.
+     * @param deployer A deployer's address.
+     * @param wallet The class instance implemented IWallet to sign transaction.
+     * @return KIP17
+     * @throws Exception
+     */
     public static KIP17 deploy(Caver caver, KIP17DeployParams tokenInfo, String deployer, IWallet wallet) throws Exception {
         List deployArgument = Arrays.asList(tokenInfo.getName(), tokenInfo.getSymbol());
         ContractDeployParams contractDeployParams = new ContractDeployParams(KIP17ConstantData.BINARY, deployArgument);

--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -155,7 +155,7 @@ public class KIP17 extends Contract {
      */
     public KIP17 clone() {
         try {
-            KIP17 kip17 = new KIP17(this.getCaver());
+            KIP17 kip17 = new KIP17(this.getCaver(), this.contractAddress);
             kip17.setWallet(this.getWallet());
 
             return kip17;

--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -155,7 +155,7 @@ public class KIP17 extends Contract {
      */
     public KIP17 clone() {
         try {
-            KIP17 kip17 = new KIP17(this.getCaver(), this.contractAddress);
+            KIP17 kip17 = new KIP17(this.getCaver(), this.getContractAddress());
             kip17.setWallet(this.getWallet());
 
             return kip17;

--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -134,7 +134,10 @@ public class KIP17 extends Contract {
      */
     public KIP17 clone() {
         try {
-            return new KIP17(this.getCaver());
+            KIP17 kip17 = new KIP17(this.getCaver());
+            kip17.setWallet(this.getWallet());
+
+            return kip17;
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -149,7 +152,10 @@ public class KIP17 extends Contract {
      */
     public KIP17 clone(String tokenAddress) {
         try {
-            return new KIP17(this.getCaver(), tokenAddress);
+            KIP17 kip17 = new KIP17(this.getCaver(), tokenAddress);
+            kip17.setWallet(this.getWallet());
+
+            return kip17;
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -22,6 +22,7 @@ import com.klaytn.caver.contract.ContractDeployParams;
 import com.klaytn.caver.contract.SendOptions;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.wallet.IWallet;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.utils.Numeric;
@@ -97,6 +98,11 @@ public class KIP17 extends Contract {
         return deploy(caver, deployParams, deployer);
     }
 
+    public static KIP17 deploy(Caver caver, String deployer, String name, String symbol, IWallet wallet) throws Exception {
+        KIP17DeployParams deployParams = new KIP17DeployParams(name, symbol);
+        return deploy(caver, deployParams, deployer, wallet);
+    }
+
     /**
      * Deploy KIP17 contract
      * It must add deployer's keyring in caver.wallet.
@@ -107,11 +113,16 @@ public class KIP17 extends Contract {
      * @throws Exception
      */
     public static KIP17 deploy(Caver caver, KIP17DeployParams tokenInfo, String deployer) throws Exception {
+        return deploy(caver, tokenInfo, deployer, caver.getWallet());
+    }
+
+    public static KIP17 deploy(Caver caver, KIP17DeployParams tokenInfo, String deployer, IWallet wallet) throws Exception {
         List deployArgument = Arrays.asList(tokenInfo.getName(), tokenInfo.getSymbol());
         ContractDeployParams contractDeployParams = new ContractDeployParams(KIP17ConstantData.BINARY, deployArgument);
         SendOptions sendOptions = new SendOptions(deployer, BigInteger.valueOf(6500000));
 
         KIP17 kip17 = new KIP17(caver);
+        kip17.setWallet(wallet);
         kip17.deploy(contractDeployParams, sendOptions);
 
         return kip17;

--- a/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
@@ -157,7 +157,7 @@ public class KIP7 extends Contract {
     @Override
     public KIP7 clone() {
         try {
-            KIP7 kip7 = new KIP7(this.getCaver(), this.contractAddress);
+            KIP7 kip7 = new KIP7(this.getCaver(), this.getContractAddress());
             kip7.setWallet(this.getWallet());
             return kip7;
         } catch (IOException e) {

--- a/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
@@ -97,6 +97,19 @@ public class KIP7 extends Contract {
         return deploy(caver, params, deployer);
     }
 
+    /**
+     * Deploy KIP-7 contract.
+     * The wallet used in the contract is set to the wallet type passed as a parameter of the method.
+     * @param caver A Caver instance.
+     * @param deployer A deployer's address.
+     * @param name A KIP-7 contract name.
+     * @param symbol A KIP-7 contract symbol.
+     * @param decimals A KIP-7 contract decimals.
+     * @param initialSupply A KIP-7 contract initial supply.
+     * @param wallet The class instance implemented IWallet to sign transaction.
+     * @return KIP7
+     * @throws Exception
+     */
     public static KIP7 deploy(Caver caver, String deployer, String name, String symbol, int decimals, BigInteger initialSupply, IWallet wallet) throws Exception {
         KIP7DeployParams params = new KIP7DeployParams(name, symbol, decimals, initialSupply);
         return deploy(caver, params, deployer, wallet);
@@ -115,6 +128,16 @@ public class KIP7 extends Contract {
         return deploy(caver, tokenInfo, deployer, caver.getWallet());
     }
 
+    /**
+     * Deploy KIP-7 contract.
+     * The wallet used in the contract is set to the wallet type passed as a parameter of the method.
+     * @param caver A Caver instance
+     * @param tokenInfo The KIP-7 contract's deploy parameter values
+     * @param deployer A deployer's address
+     * @param wallet The class instance implemented IWallet to sign transaction.
+     * @return KIP7
+     * @throws Exception
+     */
     public static KIP7 deploy(Caver caver, KIP7DeployParams tokenInfo, String deployer, IWallet wallet) throws Exception {
         List deployArgument = Arrays.asList(tokenInfo.getName(), tokenInfo.getSymbol(), tokenInfo.getDecimals(), tokenInfo.getInitialSupply());
         ContractDeployParams contractDeployParams = new ContractDeployParams(KIP7ConstantData.BINARY, deployArgument);

--- a/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
@@ -22,6 +22,7 @@ import com.klaytn.caver.contract.ContractDeployParams;
 import com.klaytn.caver.contract.SendOptions;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.wallet.IWallet;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.utils.Numeric;
@@ -96,6 +97,11 @@ public class KIP7 extends Contract {
         return deploy(caver, params, deployer);
     }
 
+    public static KIP7 deploy(Caver caver, String deployer, String name, String symbol, int decimals, BigInteger initialSupply, IWallet wallet) throws Exception {
+        KIP7DeployParams params = new KIP7DeployParams(name, symbol, decimals, initialSupply);
+        return deploy(caver, params, deployer, wallet);
+    }
+
     /**
      * Deploy KIP-7 contract.
      * It must add deployer's keyring in caver.wallet.
@@ -106,11 +112,16 @@ public class KIP7 extends Contract {
      * @throws Exception
      */
     public static KIP7 deploy(Caver caver, KIP7DeployParams tokenInfo, String deployer) throws Exception {
+        return deploy(caver, tokenInfo, deployer, caver.getWallet());
+    }
+
+    public static KIP7 deploy(Caver caver, KIP7DeployParams tokenInfo, String deployer, IWallet wallet) throws Exception {
         List deployArgument = Arrays.asList(tokenInfo.getName(), tokenInfo.getSymbol(), tokenInfo.getDecimals(), tokenInfo.getInitialSupply());
         ContractDeployParams contractDeployParams = new ContractDeployParams(KIP7ConstantData.BINARY, deployArgument);
         SendOptions sendOptions = new SendOptions(deployer, BigInteger.valueOf(4000000));
 
         KIP7 kip7 = new KIP7(caver);
+        kip7.setWallet(wallet);
         kip7.deploy(contractDeployParams, sendOptions);
 
         return kip7;

--- a/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
@@ -157,7 +157,7 @@ public class KIP7 extends Contract {
     @Override
     public KIP7 clone() {
         try {
-            KIP7 kip7 = new KIP7(this.getCaver());
+            KIP7 kip7 = new KIP7(this.getCaver(), this.contractAddress);
             kip7.setWallet(this.getWallet());
             return kip7;
         } catch (IOException e) {

--- a/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
@@ -134,7 +134,9 @@ public class KIP7 extends Contract {
     @Override
     public KIP7 clone() {
         try {
-            return new KIP7(this.getCaver());
+            KIP7 kip7 = new KIP7(this.getCaver());
+            kip7.setWallet(this.getWallet());
+            return kip7;
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -148,7 +150,9 @@ public class KIP7 extends Contract {
      */
     public KIP7 clone(String tokenAddress) {
         try {
-            return new KIP7(this.getCaver(), tokenAddress);
+            KIP7 kip7 = new KIP7(this.getCaver(), tokenAddress);
+            kip7.setWallet(this.getWallet());
+            return kip7;
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/core/src/test/java/com/klaytn/caver/common/ContractTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ContractTest.java
@@ -7,6 +7,7 @@ import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.request.KlayLogFilter;
 import com.klaytn.caver.methods.response.KlayLogs;
 import com.klaytn.caver.methods.response.TransactionReceipt;
+import com.klaytn.caver.wallet.KeyringContainer;
 import com.klaytn.caver.wallet.keyring.KeyringFactory;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
@@ -1294,6 +1295,19 @@ public class ContractTest {
         assertEquals("0x0000000000000000000000003cd93ba290712e6d28ac98f2b820faf799ae8fdb", log[0].getParams().getResult().getTopics().get(2));
 
         webSocketService.close();
+    }
 
+    @Test
+    public void setWallet() throws IOException {
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+        Contract contract = new Contract(caver, jsonObj, contractAddress);
+
+        assertEquals(0, ((KeyringContainer)contract.getWallet()).length());
+
+        KeyringContainer container = new KeyringContainer();
+        container.generate(3);
+
+        contract.setWallet(container);
+        assertEquals(3, ((KeyringContainer)contract.getWallet()).length());
     }
 }

--- a/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
@@ -2,12 +2,13 @@ package com.klaytn.caver.common;
 
 import com.klaytn.caver.Caver;
 import com.klaytn.caver.contract.SendOptions;
-import com.klaytn.caver.kct.KIP7;
 import com.klaytn.caver.kct.kip17.KIP17;
 import com.klaytn.caver.kct.kip17.KIP17DeployParams;
+import com.klaytn.caver.kct.kip7.KIP7;
 import com.klaytn.caver.methods.response.TransactionReceipt;
 import com.klaytn.caver.tx.gas.DefaultGasProvider;
 import com.klaytn.caver.utils.Utils;
+import com.klaytn.caver.wallet.KeyringContainer;
 import com.klaytn.caver.wallet.keyring.KeyringFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -89,6 +90,20 @@ public class KIP17Test {
                 e.printStackTrace();
                 fail();
             }
+        }
+
+        @Test
+        public void cloneTestWithSetWallet() throws IOException {
+            Caver caver = new Caver(Caver.DEFAULT_URL);
+            KIP17 kip17 = new KIP17(caver);
+
+            KeyringContainer container = new KeyringContainer();
+            container.generate(3);
+
+            kip17.setWallet(container);
+            KIP17 cloned = kip17.clone();
+
+            assertEquals(3, ((KeyringContainer)cloned.getWallet()).length());
         }
     }
 

--- a/core/src/test/java/com/klaytn/caver/common/KIP7Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP7Test.java
@@ -6,6 +6,7 @@ import com.klaytn.caver.kct.kip7.KIP7;
 import com.klaytn.caver.kct.kip7.KIP7DeployParams;
 import com.klaytn.caver.methods.response.TransactionReceipt;
 import com.klaytn.caver.utils.Utils;
+import com.klaytn.caver.wallet.KeyringContainer;
 import com.klaytn.caver.wallet.keyring.KeyringFactory;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -100,7 +101,20 @@ public class KIP7Test {
                 e.printStackTrace();
                 fail();
             }
+        }
 
+        @Test
+        public void cloneTestWithSetWallet() throws IOException {
+            Caver caver = new Caver(Caver.DEFAULT_URL);
+            KIP7 kip7 = new KIP7(caver);
+
+            KeyringContainer container = new KeyringContainer();
+            container.generate(3);
+
+            kip7.setWallet(container);
+            KIP7 cloned = kip7.clone();
+
+            assertEquals(3, ((KeyringContainer)cloned.getWallet()).length());
         }
     }
 


### PR DESCRIPTION
## Proposed changes

This PR introduces support setWallet() in Contract.
  - User can set wallet implemented IWallet interface and use to sign transaction in Contract.
  - Modified clone() function to clone wallet in instance together.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
