### PR TITLE
add constructor in SendOptions class.

### DIFF
--- a/core/src/main/java/com/klaytn/caver/contract/SendOptions.java
+++ b/core/src/main/java/com/klaytn/caver/contract/SendOptions.java
@@ -47,6 +47,17 @@ public class SendOptions {
     public SendOptions() {
 
     }
+
+    /**
+     * Creates a SendOption instance.
+     * It should only be used when executing KIP7 / KIP7 class methods.
+     * Because the KIP7 / KIP7 class method automatically estimates gas.
+     * @param from
+     */
+    public SendOptions(String from) {
+        this(from, (String)null);
+    }
+
     /**
      * Creates a SendOption instance.
      * It sets value to 0x0.

--- a/core/src/main/java/com/klaytn/caver/contract/SendOptions.java
+++ b/core/src/main/java/com/klaytn/caver/contract/SendOptions.java
@@ -51,7 +51,7 @@ public class SendOptions {
     /**
      * Creates a SendOption instance.
      * It should only be used when executing KIP7 / KIP7 class methods.
-     * Because the KIP7 / KIP7 class method automatically estimates gas.
+     * Because if gas passed to the method is null, the KIP7 / KIP7 class method automatically estimates gas.
      * @param from
      */
     public SendOptions(String from) {

--- a/core/src/main/java/com/klaytn/caver/contract/SendOptions.java
+++ b/core/src/main/java/com/klaytn/caver/contract/SendOptions.java
@@ -52,7 +52,7 @@ public class SendOptions {
      * Creates a SendOption instance.
      * It should only be used when executing KIP7 / KIP7 class methods.
      * Because if gas passed to the method is null, the KIP7 / KIP7 class method automatically estimates gas.
-     * @param from
+     * @param from The address of the sender
      */
     public SendOptions(String from) {
         this(from, (String)null);


### PR DESCRIPTION
## Proposed changes

This PR add a constructor with only `from`  in SendOptions class
  - It should only be used when executing KIP7 / KIP7 class methods. Because if gas passed to the method is null, the KIP7 / KIP7 class method automatically estimates gas.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
