### PR TITLE
apply a legacy, fail string in fromRoleBasedPublicKeysAndOptions()

### DIFF
--- a/core/src/main/java/com/klaytn/caver/account/AccountKeyRoleBased.java
+++ b/core/src/main/java/com/klaytn/caver/account/AccountKeyRoleBased.java
@@ -130,7 +130,7 @@ public class AccountKeyRoleBased implements IAccountKey{
         /*
         * pubArray must have up to three item.
         * each item can have
-        * {String, String...}, {}
+        * {String, String...}, {}, {"fail"}, {"legacy"}
         *
         * options must have up to three item.
         * Valid WeightedMultiSigOption or Empty WeightedMultiSigOption
@@ -161,8 +161,15 @@ public class AccountKeyRoleBased implements IAccountKey{
             }
             //Set AccountKeyPublic
             else if (publicKeyArr.length == 1 && weightedMultiSigOption.isEmpty()) {
+                if(publicKeyArr[0].equals("legacy")) {
+                    accountKeys.add(new AccountKeyLegacy());
+                } else if (publicKeyArr[0].equals("fail")) {
+                    accountKeys.add(new AccountKeyFail());
+                } else {
                     accountKeys.add(AccountKeyPublic.fromPublicKey(publicKeyArr[0]));
-                    continue;
+                }
+
+                continue;
             }
 
             if (weightedMultiSigOption.isEmpty()) {

--- a/core/src/test/java/com/klaytn/caver/common/AccountKeyTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/AccountKeyTest.java
@@ -990,5 +990,67 @@ public class AccountKeyTest {
 
             assertEquals(expectedEncodedData, accountKeyRoleBased.getRLPEncoding());
         }
+
+        @Test
+        public void fromRoleBasedPublicKeysAndOptionsWithString() {
+            String[][] expectedPublicKey = {
+                    {
+                        "fail"
+                    },
+                    {
+                        "0xc10b598a1a3ba252acc21349d61c2fbd9bc8c15c50a5599f420cccc3291f9bf9803a1898f45b2770eda7abce70e8503b5e82b748ec0ce557ac9f4f4796965e4e"
+                    },
+                    {
+                        "legacy"
+                    }
+            };
+
+            WeightedMultiSigOptions transactionKeyOption = new WeightedMultiSigOptions();
+            WeightedMultiSigOptions accountUpdateKeyOption = new WeightedMultiSigOptions();
+            WeightedMultiSigOptions feePayerKeyOption = new WeightedMultiSigOptions();
+
+            List<WeightedMultiSigOptions> options = new ArrayList<>();
+            options.add(transactionKeyOption);
+            options.add(accountUpdateKeyOption);
+            options.add(feePayerKeyOption);
+
+            AccountKeyRoleBased roleBased = AccountKeyRoleBased.fromRoleBasedPublicKeysAndOptions(Arrays.asList(expectedPublicKey), options);
+            assertTrue(roleBased.getRoleTransactionKey() instanceof AccountKeyFail);
+            assertTrue(roleBased.getRoleAccountUpdateKey() instanceof AccountKeyPublic);
+            checkPublicKey(expectedPublicKey[1][0], ((AccountKeyPublic) roleBased.getRoleAccountUpdateKey()).getPublicKey());
+            assertTrue(roleBased.getRoleFeePayerKey() instanceof AccountKeyLegacy);
+        }
+
+        @Test
+        public void fromRoleBasedPublicKeysAndOptionsWithStringAndWeightedMultiSig() {
+            String[][] expectedPublicKey = {
+                    {
+                            "legacy"
+                    },
+                    {
+                            "0xc10b598a1a3ba252acc21349d61c2fbd9bc8c15c50a5599f420cccc3291f9bf9803a1898f45b2770eda7abce70e8503b5e82b748ec0ce557ac9f4f4796965e4e",
+                            "0x1769a9196f523c419be50c26419ebbec34d3d6aa8b59da834212f13dbec9a9c12a4d0eeb91d7bd5d592653d43dd0593cfe24cb20a5dbef05832932e7c7191bf6"
+                    },
+                    {
+                            "fail"
+                    }
+            };
+
+            BigInteger[] weightArr = new BigInteger[]{BigInteger.ONE, BigInteger.ONE};
+            WeightedMultiSigOptions transactionKeyOption = new WeightedMultiSigOptions();
+            WeightedMultiSigOptions accountUpdateKeyOption = new WeightedMultiSigOptions(BigInteger.valueOf(2), Arrays.asList(weightArr));
+            WeightedMultiSigOptions feePayerKeyOption = new WeightedMultiSigOptions();
+
+            List<WeightedMultiSigOptions> options = new ArrayList<>();
+            options.add(transactionKeyOption);
+            options.add(accountUpdateKeyOption);
+            options.add(feePayerKeyOption);
+
+            AccountKeyRoleBased roleBased = AccountKeyRoleBased.fromRoleBasedPublicKeysAndOptions(Arrays.asList(expectedPublicKey), options);
+            assertTrue(roleBased.getRoleTransactionKey() instanceof AccountKeyLegacy);
+            assertTrue(roleBased.getRoleAccountUpdateKey() instanceof AccountKeyWeightedMultiSig);
+            checkAccountKeyWeightedMultiSig(expectedPublicKey[1], accountUpdateKeyOption, (AccountKeyWeightedMultiSig)roleBased.getRoleAccountUpdateKey());
+            assertTrue(roleBased.getRoleFeePayerKey() instanceof AccountKeyFail);
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR can be created AccountKeyFail / AccountKeyLegacy instance through "fail" and "legacy" string in public key array in fromRoleBasedPublicKeysAndOptions()

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
