### PR TITLE
add INTERFACE enum that defined KCT interface name and value

### DIFF
--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -67,22 +67,6 @@ public class KIP17 extends Contract {
     public static final String FUNCTION_TRANSFER_FROM = "transferFrom";
     public static final String FUNCTION_UNPAUSE = "unpause";
 
-    public static final String INTERFACE_ID_IKIP17 = "0x80ac58cd";
-    public static final String INTERFACE_ID_IKIP17_METADATA = "0x5b5e139f";
-    public static final String INTERFACE_ID_IKIP17_ENUMERABLE = "0x780e9d63";
-    public static final String INTERFACE_ID_IKIP17_MINTABLE = "0xeab83e20";
-    public static final String INTERFACE_ID_IKIP17_METADATA_MINTABLE = "0xfac27f46";
-    public static final String INTERFACE_ID_IKIP17_BURNABLE = "0x42966c68";
-    public static final String INTERFACE_ID_IKIP17_PAUSABLE = "0x4d5507ff";
-
-    public static final String INTERFACE_NAME_IKIP17 = "IKIP17";
-    public static final String INTERFACE_NAME_IKIP17_METADATA = "IKIP17Metadata";
-    public static final String INTERFACE_NAME_IKIP17_ENUMERABLE = "IKIP17Enumerable";
-    public static final String INTERFACE_NAME_IKIP17_MINTABLE = "IKIP17Mintable";
-    public static final String INTERFACE_NAME_IKIP17_METADATA_MINTABLE = "IKIP17MetadataMintable";
-    public static final String INTERFACE_NAME_IKIP17_BURNABLE = "IKIP17Burnable";
-    public static final String INTERFACE_NAME_IKIP17_PAUSABLE = "IKIP17Pausable";
-
     public enum INTERFACE {
         IKIP17("IKIP17", "0x80ac58cd"),
         IKIP17_METADATA("IKIP17Metadata", "0x5b5e139f"),

--- a/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip17/KIP17.java
@@ -21,6 +21,7 @@ import com.klaytn.caver.contract.Contract;
 import com.klaytn.caver.contract.ContractDeployParams;
 import com.klaytn.caver.contract.SendOptions;
 import com.klaytn.caver.kct.kip13.KIP13;
+import com.klaytn.caver.kct.kip7.KIP7;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.TransactionReceipt;
 import com.klaytn.caver.wallet.IWallet;
@@ -32,10 +33,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,6 +74,40 @@ public class KIP17 extends Contract {
     public static final String INTERFACE_ID_IKIP17_METADATA_MINTABLE = "0xfac27f46";
     public static final String INTERFACE_ID_IKIP17_BURNABLE = "0x42966c68";
     public static final String INTERFACE_ID_IKIP17_PAUSABLE = "0x4d5507ff";
+
+    public static final String INTERFACE_NAME_IKIP17 = "IKIP17";
+    public static final String INTERFACE_NAME_IKIP17_METADATA = "IKIP17Metadata";
+    public static final String INTERFACE_NAME_IKIP17_ENUMERABLE = "IKIP17Enumerable";
+    public static final String INTERFACE_NAME_IKIP17_MINTABLE = "IKIP17Mintable";
+    public static final String INTERFACE_NAME_IKIP17_METADATA_MINTABLE = "IKIP17MetadataMintable";
+    public static final String INTERFACE_NAME_IKIP17_BURNABLE = "IKIP17Burnable";
+    public static final String INTERFACE_NAME_IKIP17_PAUSABLE = "IKIP17Pausable";
+
+    public enum INTERFACE {
+        IKIP17("IKIP17", "0x80ac58cd"),
+        IKIP17_METADATA("IKIP17Metadata", "0x5b5e139f"),
+        IKIP17_ENUMERABLE("IKIP17Enumerable", "0x780e9d63"),
+        IKIP17_MINTABLE("IKIP17Mintable", "0xeab83e20"),
+        IKIP17_METADATA_MINTABLE("IKIP17MetadataMintable", "0xfac27f46"),
+        IKIP17_BURNABLE("IKIP17Burnable", "0x42966c68"),
+        IKIP17_PAUSABLE("IKIP17Pausable", "0x4d5507ff");
+
+        String name;
+        String id;
+
+        INTERFACE(String name, String id) {
+            this.name = name;
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
 
     /**
      * Creates a KIP17 instance.
@@ -205,16 +237,6 @@ public class KIP17 extends Contract {
      * @return Map&lt;String, Boolean&gt;
      */
     public static Map<String, Boolean> detectInterface(Caver caver, String contractAddress) {
-        Map<String, Boolean> result = Stream.of(
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP17, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP17_ENUMERABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP17_BURNABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP17_PAUSABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP17_MINTABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP17_METADATA, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP17_METADATA_MINTABLE, false))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
         KIP13 kip13;
         try {
             kip13 = new KIP13(caver, contractAddress);
@@ -226,7 +248,9 @@ public class KIP17 extends Contract {
             throw new RuntimeException("This contract does not support KIP-13.");
         }
 
-        result.entrySet().forEach(entry -> entry.setValue(kip13.sendQuery(entry.getKey())));
+        Map<String, Boolean> result = new HashMap<>();
+        Arrays.stream(INTERFACE.values())
+                .forEach(element -> result.put(element.getName(), kip13.sendQuery(element.getId())));
         return result;
     }
 

--- a/core/src/main/java/com/klaytn/caver/kct/kip37/KIP37.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip37/KIP37.java
@@ -22,6 +22,7 @@ import com.klaytn.caver.contract.ContractDeployParams;
 import com.klaytn.caver.contract.SendOptions;
 import com.klaytn.caver.kct.kip13.KIP13;
 import com.klaytn.caver.kct.kip17.KIP17;
+import com.klaytn.caver.kct.kip7.KIP7;
 import com.klaytn.caver.methods.request.CallObject;
 import com.klaytn.caver.methods.response.TransactionReceipt;
 import com.klaytn.caver.wallet.IWallet;
@@ -37,10 +38,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -74,6 +72,36 @@ public class KIP37 extends Contract {
     public static final String INTERFACE_ID_IKIP37_MINTABLE = "0xdfd9d9ec";
     public static final String INTERFACE_ID_IKIP37_BURNABLE = "0x9e094e9e";
     public static final String INTERFACE_ID_IKIP37_PAUSABLE = "0x0e8ffdb7";
+
+    public static final String INTERFACE_NAME_IKIP37 = "IKIP37";
+    public static final String INTERFACE_NAME_IKIP37_METADATA = "IKIP37Metatdata";
+    public static final String INTERFACE_NAME_IKIP37_MINTABLE = "IKIP37Mintable";
+    public static final String INTERFACE_NAME_IKIP37_BURNABLE = "IKIP37Burnable";
+    public static final String INTERFACE_NAME_IKIP37_PAUSABLE = "IKIP37Pausable";
+
+    public enum INTERFACE {
+        IKIP37("IKIP37", "0x6433ca1f"),
+        IKIP37_METADATA("IKIP37Metatdata", "0x0e89341c"),
+        IKIP37_MINTABLE("IKIP37Mintable", "0xdfd9d9ec"),
+        IKIP37_BURNABLE("IKIP37Burnable", "0x9e094e9e"),
+        IKIP37_PAUSABLE("IKIP37Pausable", "0x0e8ffdb7");
+
+        String name;
+        String id;
+
+        INTERFACE(String name, String id) {
+            this.name = name;
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
 
     /**
      * Creates a KIP37 instance.
@@ -192,14 +220,6 @@ public class KIP37 extends Contract {
      * @return Map&lt;String, Boolean&gt;
      */
     public static Map<String, Boolean> detectInterface(Caver caver, String contractAddress) {
-        Map<String, Boolean> result = Stream.of(
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP37, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP37_BURNABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP37_MINTABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP37_METADATA, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP37_PAUSABLE, false))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
         KIP13 kip13;
         try {
             kip13 = new KIP13(caver, contractAddress);
@@ -211,7 +231,9 @@ public class KIP37 extends Contract {
             throw new RuntimeException("This contract does not support KIP-13.");
         }
 
-        result.entrySet().forEach(entry -> entry.setValue(kip13.sendQuery(entry.getKey())));
+        Map<String, Boolean> result = new HashMap<>();
+        Arrays.stream(INTERFACE.values())
+                .forEach(element -> result.put(element.getName(), kip13.sendQuery(element.getId())));
         return result;
     }
 

--- a/core/src/main/java/com/klaytn/caver/kct/kip37/KIP37.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip37/KIP37.java
@@ -67,18 +67,6 @@ public class KIP37 extends Contract {
     public static final String FUNCTION_RENOUNCE_MINTER = "renounceMinter";
     public static final String FUNCTION_SUPPORTS_INTERFACE = "supportsInterface";
 
-    public static final String INTERFACE_ID_IKIP37 = "0x6433ca1f";
-    public static final String INTERFACE_ID_IKIP37_METADATA = "0x0e89341c";
-    public static final String INTERFACE_ID_IKIP37_MINTABLE = "0xdfd9d9ec";
-    public static final String INTERFACE_ID_IKIP37_BURNABLE = "0x9e094e9e";
-    public static final String INTERFACE_ID_IKIP37_PAUSABLE = "0x0e8ffdb7";
-
-    public static final String INTERFACE_NAME_IKIP37 = "IKIP37";
-    public static final String INTERFACE_NAME_IKIP37_METADATA = "IKIP37Metatdata";
-    public static final String INTERFACE_NAME_IKIP37_MINTABLE = "IKIP37Mintable";
-    public static final String INTERFACE_NAME_IKIP37_BURNABLE = "IKIP37Burnable";
-    public static final String INTERFACE_NAME_IKIP37_PAUSABLE = "IKIP37Pausable";
-
     public enum INTERFACE {
         IKIP37("IKIP37", "0x6433ca1f"),
         IKIP37_METADATA("IKIP37Metatdata", "0x0e89341c"),

--- a/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
+++ b/core/src/main/java/com/klaytn/caver/kct/kip7/KIP7.java
@@ -33,8 +33,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class KIP7 extends Contract {
 
@@ -63,11 +61,29 @@ public class KIP7 extends Contract {
     private static final String FUNCTION_TRANSFER_FROM = "transferFrom";
     private static final String FUNCTION_UNPAUSE = "unpause";
 
-    public static final String INTERFACE_ID_IKIP7 = "0x65787371";
-    public static final String INTERFACE_ID_IKIP7_METADATA = "0xa219a025";
-    public static final String INTERFACE_ID_IKIP7_MINTABLE = "0xeab83e20";
-    public static final String INTERFACE_ID_IKIP7_BURNABLE = "0x3b5a0bf8";
-    public static final String INTERFACE_ID_IKIP7_PAUSABLE = "0x4d5507ff";
+    public enum INTERFACE {
+        IKIP7("IKIP7", "0x65787371"),
+        IKIP7_METADATA("IKIP7Metatdata", "0xa219a025"),
+        IKIP7_MINTABLE("IKIP7Mintable", "0xeab83e20"),
+        IKIP7_BURNABLE("IKIP7Burnable", "0x3b5a0bf8"),
+        IKIP7_PAUSABLE("IKIP7Pausable", "0x4d5507ff");
+
+        String name;
+        String id;
+
+        INTERFACE(String name, String id) {
+            this.name = name;
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
 
 
 
@@ -201,14 +217,6 @@ public class KIP7 extends Contract {
      * @return
      */
     public static Map<String, Boolean> detectInterface(Caver caver, String contractAddress) {
-        Map<String, Boolean> result = Stream.of(
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP7, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP7_BURNABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP7_MINTABLE, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP7_METADATA, false),
-                new AbstractMap.SimpleEntry<>(INTERFACE_ID_IKIP7_PAUSABLE, false))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
         KIP13 kip13;
         try {
             kip13 = new KIP13(caver, contractAddress);
@@ -220,7 +228,10 @@ public class KIP7 extends Contract {
             throw new RuntimeException("This contract does not support KIP-13.");
         }
 
-        result.entrySet().forEach(entry -> entry.setValue(kip13.sendQuery(entry.getKey())));
+        Map<String, Boolean> result = new HashMap<>();
+        Arrays.stream(INTERFACE.values())
+                .forEach(element -> result.put(element.getName(), kip13.sendQuery(element.getId())));
+
         return result;
     }
 

--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
@@ -453,7 +453,7 @@ abstract public class AbstractTransaction {
         }
 
         if(this.nonce.equals("0x") || this.chainId.equals("0x") || this.gasPrice.equals("0x")) {
-            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId, gasPrice");
+            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId, gasPrice), Didn't you set a `klaytnCall` field in Transaction instance?");
         }
     }
 

--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
@@ -453,7 +453,7 @@ abstract public class AbstractTransaction {
         }
 
         if(this.nonce.equals("0x") || this.chainId.equals("0x") || this.gasPrice.equals("0x")) {
-            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId, gasPrice), Didn't you set a `klaytnCall` field in Transaction instance?");
+            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId, gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
         }
     }
 

--- a/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP17Test.java
@@ -807,25 +807,26 @@ public class KIP17Test {
         @Test
         public void detectInterface() {
             Map<String, Boolean> result = kip17Contract.detectInterface();
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_ENUMERABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_MINTABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA_MINTABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_BURNABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_PAUSABLE));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_ENUMERABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_MINTABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA_MINTABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_BURNABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_PAUSABLE.getName()));
+
         }
 
         @Test
         public void detectInterface_staticMethod() {
             Map<String, Boolean> result = KIP17.detectInterface(kip17Contract.getCaver(), kip17Contract.getContractAddress());
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_ENUMERABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_MINTABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA_MINTABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_BURNABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_PAUSABLE));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_ENUMERABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_MINTABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA_MINTABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_BURNABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_PAUSABLE.getName()));
         }
 
         @Test
@@ -834,13 +835,13 @@ public class KIP17Test {
             contract.deploy(new SendOptions(LUMAN.getAddress(), BigInteger.valueOf(10000000)), bytecodeWithFullMetadataMintable, "Test", "TST");
 
             Map<String, Boolean> result = KIP17.detectInterface(caver, contract.getContractAddress());
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_ENUMERABLE));
-            assertFalse(result.get(KIP17.INTERFACE_ID_IKIP17_MINTABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA_MINTABLE));
-            assertFalse(result.get(KIP17.INTERFACE_ID_IKIP17_BURNABLE));
-            assertFalse(result.get(KIP17.INTERFACE_ID_IKIP17_PAUSABLE));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_ENUMERABLE.getName()));
+            assertFalse(result.get(KIP17.INTERFACE.IKIP17_MINTABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA_MINTABLE.getName()));
+            assertFalse(result.get(KIP17.INTERFACE.IKIP17_BURNABLE.getName()));
+            assertFalse(result.get(KIP17.INTERFACE.IKIP17_PAUSABLE.getName()));
         }
 
         @Test
@@ -852,13 +853,13 @@ public class KIP17Test {
             contract.deploy(new SendOptions(LUMAN.getAddress(), BigInteger.valueOf(10000000)), byteCodeNotSupportedKIP13);
 
             Map<String, Boolean> result = KIP17.detectInterface(caver, contract.getContractAddress());
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_ENUMERABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_MINTABLE));
-            assertTrue(result.get(KIP17.INTERFACE_ID_IKIP17_METADATA_MINTABLE));
-            assertFalse(result.get(KIP17.INTERFACE_ID_IKIP17_BURNABLE));
-            assertFalse(result.get(KIP17.INTERFACE_ID_IKIP17_PAUSABLE));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_ENUMERABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_MINTABLE.getName()));
+            assertTrue(result.get(KIP17.INTERFACE.IKIP17_METADATA_MINTABLE.getName()));
+            assertFalse(result.get(KIP17.INTERFACE.IKIP17_BURNABLE.getName()));
+            assertFalse(result.get(KIP17.INTERFACE.IKIP17_PAUSABLE.getName()));
         }
     }
 }

--- a/core/src/test/java/com/klaytn/caver/common/KIP37Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP37Test.java
@@ -974,21 +974,23 @@ public class KIP37Test {
         @Test
         public void detectInterface() {
             Map<String, Boolean> result = kip37.detectInterface();
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_BURNABLE));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_METADATA));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_MINTABLE));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_PAUSABLE));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_BURNABLE.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_METADATA.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_MINTABLE.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_PAUSABLE.getName()));
+
+            result.entrySet().forEach(entry -> System.out.println("Interface ID : " + entry.getKey() + " - " + entry.getValue()));
         }
 
         @Test
         public void detectInterface_staticMethod() {
             Map<String, Boolean> result = KIP37.detectInterface(kip37.getCaver(), kip37.getContractAddress());
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_BURNABLE));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_METADATA));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_MINTABLE));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_PAUSABLE));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_BURNABLE.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_METADATA.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_MINTABLE.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_PAUSABLE.getName()));
         }
 
         @Test
@@ -997,11 +999,11 @@ public class KIP37Test {
             contract.deploy(new SendOptions(LUMAN.getAddress(), BigInteger.valueOf(10000000)), byteCodeWithMintable, "uri");
 
             Map<String, Boolean> result = KIP37.detectInterface(caver, contract.getContractAddress());
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37));
-            assertFalse(result.get(KIP37.INTERFACE_ID_IKIP37_BURNABLE));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_METADATA));
-            assertFalse(result.get(KIP37.INTERFACE_ID_IKIP37_MINTABLE));
-            assertFalse(result.get(KIP37.INTERFACE_ID_IKIP37_PAUSABLE));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37.getName()));
+            assertFalse(result.get(KIP37.INTERFACE.IKIP37_BURNABLE.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_METADATA.getName()));
+            assertFalse(result.get(KIP37.INTERFACE.IKIP37_MINTABLE.getName()));
+            assertFalse(result.get(KIP37.INTERFACE.IKIP37_PAUSABLE.getName()));
         }
 
         @Test
@@ -1010,11 +1012,11 @@ public class KIP37Test {
             contract.deploy(new SendOptions(LUMAN.getAddress(), BigInteger.valueOf(10000000)), byteCodeWithoutBurnablePausable, "uri");
 
             Map<String, Boolean> result = KIP37.detectInterface(caver, contract.getContractAddress());
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37));
-            assertFalse(result.get(KIP37.INTERFACE_ID_IKIP37_BURNABLE));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_METADATA));
-            assertTrue(result.get(KIP37.INTERFACE_ID_IKIP37_MINTABLE));
-            assertFalse(result.get(KIP37.INTERFACE_ID_IKIP37_PAUSABLE));;
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37.getName()));
+            assertFalse(result.get(KIP37.INTERFACE.IKIP37_BURNABLE.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_METADATA.getName()));
+            assertTrue(result.get(KIP37.INTERFACE.IKIP37_MINTABLE.getName()));
+            assertFalse(result.get(KIP37.INTERFACE.IKIP37_PAUSABLE.getName()));
         }
 
         @Test

--- a/core/src/test/java/com/klaytn/caver/common/KIP7Test.java
+++ b/core/src/test/java/com/klaytn/caver/common/KIP7Test.java
@@ -671,21 +671,21 @@ public class KIP7Test {
         @Test
         public void detectInterface() {
             Map<String, Boolean> result = kip7contract.detectInterface();
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_BURNABLE));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_METADATA));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_MINTABLE));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_PAUSABLE));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_BURNABLE.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_METADATA.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_MINTABLE.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_PAUSABLE.getName()));
         }
 
         @Test
         public void detectInterface_staticMethod() {
             Map<String, Boolean> result = KIP7.detectInterface(kip7contract.getCaver(), kip7contract.getContractAddress());
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_BURNABLE));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_METADATA));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_MINTABLE));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_PAUSABLE));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_BURNABLE.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_METADATA.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_MINTABLE.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_PAUSABLE.getName()));
         }
 
         @Test
@@ -694,11 +694,11 @@ public class KIP7Test {
             contract.deploy(new SendOptions(LUMAN.getAddress(), BigInteger.valueOf(10000000)), byteCodeWithMintable, BigInteger.valueOf(100000000000L));
 
             Map<String, Boolean> result = KIP7.detectInterface(caver, contract.getContractAddress());
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7));
-            assertFalse(result.get(KIP7.INTERFACE_ID_IKIP7_BURNABLE));
-            assertFalse(result.get(KIP7.INTERFACE_ID_IKIP7_METADATA));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_MINTABLE));
-            assertFalse(result.get(KIP7.INTERFACE_ID_IKIP7_PAUSABLE));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7.getName()));
+            assertFalse(result.get(KIP7.INTERFACE.IKIP7_BURNABLE.getName()));
+            assertFalse(result.get(KIP7.INTERFACE.IKIP7_METADATA.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_MINTABLE.getName()));
+            assertFalse(result.get(KIP7.INTERFACE.IKIP7_PAUSABLE.getName()));
         }
 
         @Test
@@ -707,11 +707,11 @@ public class KIP7Test {
             contract.deploy(new SendOptions(LUMAN.getAddress(), BigInteger.valueOf(10000000)), byteCodeWithoutBurnablePausable, "Test", "TST", 18, BigInteger.valueOf(100000000000L));
 
             Map<String, Boolean> result = KIP7.detectInterface(caver, contract.getContractAddress());
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7));
-            assertFalse(result.get(KIP7.INTERFACE_ID_IKIP7_BURNABLE));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_METADATA));
-            assertTrue(result.get(KIP7.INTERFACE_ID_IKIP7_MINTABLE));
-            assertFalse(result.get(KIP7.INTERFACE_ID_IKIP7_PAUSABLE));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7.getName()));
+            assertFalse(result.get(KIP7.INTERFACE.IKIP7_BURNABLE.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_METADATA.getName()));
+            assertTrue(result.get(KIP7.INTERFACE.IKIP7_MINTABLE.getName()));
+            assertFalse(result.get(KIP7.INTERFACE.IKIP7_PAUSABLE.getName()));
         }
 
         @Test


### PR DESCRIPTION
## Proposed changes

This PR defined a INTERFACE enum that defined each KCT class(KIP7, KIP17, KIP37) interface name and value.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
