### PR TITLE
Added logic to parse tuple data in ABI

### DIFF
--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -133,7 +133,7 @@ public class ABI {
         result.append(method.getName());
         result.append("(");
         String params = method.getInputs().stream()
-                .map(ContractIOType::getType)
+                .map(ContractIOType::getTypeAsString)
                 .collect(Collectors.joining(","));
         result.append(params);
         result.append(")");
@@ -171,7 +171,7 @@ public class ABI {
         result.append(event.getName());
         result.append("(");
         String params = event.getInputs().stream()
-                .map(ContractIOType::getType)
+                .map(ContractIOType::getTypeAsString)
                 .collect(Collectors.joining(","));
         result.append(params);
         result.append(")");

--- a/core/src/main/java/com/klaytn/caver/abi/ABI.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABI.java
@@ -138,7 +138,8 @@ public class ABI {
         result.append(params);
         result.append(")");
 
-        return result.toString();
+        //remove "tuple" string
+        return result.toString().replace("tuple", "");
     }
 
     /**
@@ -176,7 +177,8 @@ public class ABI {
         result.append(params);
         result.append(")");
 
-        return result.toString();
+        //remove "tuple" string
+        return result.toString().replace("tuple", "");
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
@@ -133,9 +133,9 @@ public class ContractIOType {
         if(getType().contains("tuple")) {
             String typeString = getComponentAsString();
             return getType().replace("tuple", "tuple" + typeString);
-        } else {
-            return getType();
         }
+        
+        return getType();
     }
 
     private String getComponentAsString() {

--- a/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
@@ -147,11 +147,7 @@ public class ContractIOType {
 
         for(int i=0; i<this.getComponents().size(); i++) {
             ContractIOType ioType = this.components.get(i);
-            if(ioType.getType().contains("tuple")) {
-                stringBuilder.append(ioType.getTypeAsString());
-            } else {
-                stringBuilder.append(ioType.getType());
-            }
+            stringBuilder.append(ioType.getTypeAsString());
 
             if(i < this.getComponents().size() -1) {
                 stringBuilder.append(",");

--- a/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
@@ -132,7 +132,7 @@ public class ContractIOType {
     public String getTypeAsString() {
         if(getType().contains("tuple")) {
             String typeString = getComponentAsString();
-            return getType().replace("tuple", typeString);
+            return getType().replace("tuple", "tuple" + typeString);
         } else {
             return getType();
         }

--- a/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
+++ b/core/src/main/java/com/klaytn/caver/contract/ContractIOType.java
@@ -16,6 +16,8 @@
 
 package com.klaytn.caver.contract;
 
+import java.util.List;
+
 /**
  * Representing a Contract's method or event parameter information.
  */
@@ -34,6 +36,11 @@ public class ContractIOType {
      * True if the field is part of the log’s topics, false if it one of the log’s data segment.
      */
     boolean indexed;
+
+    /**
+     * A tuple type components information.
+     */
+    List<ContractIOType> components;
 
     /**
      * Creates a ContractIOType instance.
@@ -70,6 +77,14 @@ public class ContractIOType {
     }
 
     /**
+     * Getter function for components.
+     * @return List
+     */
+    public List<ContractIOType> getComponents() {
+        return components;
+    }
+
+    /**
      * Getter function for indexed
      * @return indexed.
      */
@@ -99,5 +114,50 @@ public class ContractIOType {
      */
     public void setIndexed(boolean indexed) {
         this.indexed = indexed;
+    }
+
+    /**
+     * Setter function for components
+     * @param components The tuple's components list.
+     */
+    public void setComponents(List<ContractIOType> components) {
+        this.components = components;
+    }
+
+    /**
+     * Returns a type string.
+     * If type string has a tuple, the components of the tuple are listed and returned.
+     * @return String
+     */
+    public String getTypeAsString() {
+        if(getType().contains("tuple")) {
+            String typeString = getComponentAsString();
+            return getType().replace("tuple", typeString);
+        } else {
+            return getType();
+        }
+    }
+
+    private String getComponentAsString() {
+        if(this.getComponents() == null) {
+            return "";
+        }
+
+        StringBuilder stringBuilder = new StringBuilder("(");
+
+        for(int i=0; i<this.getComponents().size(); i++) {
+            ContractIOType ioType = this.components.get(i);
+            if(ioType.getType().contains("tuple")) {
+                stringBuilder.append(ioType.getTypeAsString());
+            } else {
+                stringBuilder.append(ioType.getType());
+            }
+
+            if(i < this.getComponents().size() -1) {
+                stringBuilder.append(",");
+            }
+        }
+
+        return stringBuilder.append(")").toString();
     }
 }

--- a/core/src/test/java/com/klaytn/caver/common/ABITest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ABITest.java
@@ -1,14 +1,15 @@
 package com.klaytn.caver.common;
 
+import com.klaytn.caver.Caver;
 import com.klaytn.caver.abi.ABI;
+import com.klaytn.caver.contract.Contract;
 import com.klaytn.caver.contract.ContractIOType;
-import com.klaytn.caver.contract.ContractMethod;
 import org.junit.Test;
 import org.web3j.abi.*;
 import org.web3j.abi.datatypes.*;
 import org.web3j.abi.datatypes.generated.*;
 
-import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.util.*;
@@ -237,7 +238,7 @@ public class ABITest {
         }
     }
 
-    public static class decodeParameterTest {
+    public static class decodeParameter {
         @Test
         public void decodeBoolType() throws ClassNotFoundException {
             assertEquals(
@@ -432,7 +433,7 @@ public class ABITest {
         }
     }
 
-    public static class decodeLogTest {
+    public static class decodeLog {
         @Test
         public void decodeLog() throws ClassNotFoundException {
             List<ContractIOType> ioTypeList= Arrays.asList(
@@ -460,4 +461,48 @@ public class ABITest {
         }
     }
 
+    public static class buildFunctionEventString {
+        String TEST_ABI = "[{\"constant\":false,\"inputs\":[{\"name\":\"a\",\"type\":\"bytes32[]\"}],\"name\":\"h\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"a\",\"type\":\"uint256\"},{\"name\":\"b\",\"type\":\"uint256[]\"},{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"y\",\"type\":\"uint256\"}],\"name\":\"c\",\"type\":\"tuple[]\"}],\"name\":\"d\",\"type\":\"tuple[]\"}],\"name\":\"structArray\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"y\",\"type\":\"uint256\"}],\"name\":\"s\",\"type\":\"tuple\"}],\"name\":\"staticStruct\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"s\",\"type\":\"string\"}],\"name\":\"d\",\"type\":\"tuple\"}],\"name\":\"dynamicStruct\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"a\",\"type\":\"uint256\"}],\"name\":\"g\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"a\",\"type\":\"string\"}],\"name\":\"b\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"y\",\"type\":\"uint256\"}],\"indexed\":true,\"name\":\"t\",\"type\":\"tuple\"}],\"name\":\"STRUCT_EVENT\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"t\",\"type\":\"uint256\"}],\"name\":\"EVENT\",\"type\":\"event\"}]";
+
+//        pragma solidity >=0.4.19 <0.7.0;
+//        pragma experimental ABIEncoderV2;
+//
+//        contract Test {
+//            event STRUCT_EVENT(T indexed t);
+//            event EVENT(uint256 indexed t);
+//
+//            struct S { uint a; uint[] b; T[] c; }
+//            struct T { uint x; uint y; }
+//            struct D { uint x; string s; }
+//
+//            function staticStruct(T memory s) public;
+//            function dynamicStruct(D memory d) public;
+//            function structArray(S[] memory d) public;
+//            function g(uint a) public;
+//            function b(string memory a) public;
+//            function h(bytes32[] memory a) public;
+//        }
+        @Test
+        public void buildFunctionStringTest() throws IOException {
+            Caver caver = new Caver(Caver.DEFAULT_URL);
+            Contract contract = new Contract(caver, TEST_ABI);
+
+            assertEquals("b(string)", ABI.buildFunctionString(contract.getMethod("b")));
+            assertEquals("g(uint256)", ABI.buildFunctionString(contract.getMethod("g")));
+            assertEquals("h(bytes32[])", ABI.buildFunctionString(contract.getMethod("h")));
+
+            assertEquals("staticStruct((uint256,uint256))", ABI.buildFunctionString(contract.getMethod("staticStruct")));
+            assertEquals("dynamicStruct((uint256,string))", ABI.buildFunctionString(contract.getMethod("dynamicStruct")));
+            assertEquals("structArray((uint256,uint256[],(uint256,uint256)[])[])", ABI.buildFunctionString(contract.getMethod("structArray")));
+        }
+
+        @Test
+        public void buildEventStringTest() throws IOException {
+            Caver caver = new Caver(Caver.DEFAULT_URL);
+            Contract contract = new Contract(caver, TEST_ABI);
+
+            assertEquals("EVENT(uint256)", ABI.buildEventString(contract.getEvent("EVENT")));
+            assertEquals("STRUCT_EVENT((uint256,uint256))", ABI.buildEventString(contract.getEvent("STRUCT_EVENT")));
+        }
+    }
 }


### PR DESCRIPTION
## Proposed changes

This PR added logic to parse tuple data in ABI.
  - added ContractIOType@getTypeAsString() to make a tuple with component type string.
  - ABI.buildFunctionString() : To build function selector according to ABI spec, remove tuple string in function string 
     - it also add same logic ABI.buildEventString() 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
