### PR TITLE
Added an ABIWrapper

### DIFF
--- a/core/src/main/java/com/klaytn/caver/Caver.java
+++ b/core/src/main/java/com/klaytn/caver/Caver.java
@@ -75,8 +75,7 @@ public class Caver {
     public AccountWrapper account;
 
     /**
-     * The ContractWrapper instance.<p>
-     * It sets a HttpProvider that using DEFAULT_URL("http://localhost:8551").
+     * The ContractWrapper instance.
      */
     public ContractWrapper contract;
 
@@ -86,7 +85,8 @@ public class Caver {
     public ABIWrapper abi;
 
     /**
-     * Creates a Caver instance
+     * Creates a Caver instance<p>
+     * It sets a HttpProvider that using DEFAULT_URL("http://localhost:8551").
      */
     public Caver() {
         this(new HttpService(DEFAULT_URL));

--- a/core/src/main/java/com/klaytn/caver/Caver.java
+++ b/core/src/main/java/com/klaytn/caver/Caver.java
@@ -16,6 +16,7 @@
 
 package com.klaytn.caver;
 
+import com.klaytn.caver.abi.ABIWrapper;
 import com.klaytn.caver.account.AccountWrapper;
 import com.klaytn.caver.contract.ContractWrapper;
 import com.klaytn.caver.ipfs.IPFS;
@@ -80,6 +81,11 @@ public class Caver {
     public ContractWrapper contract;
 
     /**
+     * The ABIWrapper instance
+     */
+    public ABIWrapper abi;
+
+    /**
      * Creates a Caver instance
      */
     public Caver() {
@@ -105,6 +111,7 @@ public class Caver {
         account = new AccountWrapper();
         transaction = new TransactionWrapper(rpc.getKlay());
         contract = new ContractWrapper(this);
+        abi = new ABIWrapper();
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/abi/ABIWrapper.java
+++ b/core/src/main/java/com/klaytn/caver/abi/ABIWrapper.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2021 The caver-java Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.klaytn.caver.abi;
+
+import com.klaytn.caver.abi.datatypes.Type;
+import com.klaytn.caver.contract.ContractEvent;
+import com.klaytn.caver.contract.ContractIOType;
+import com.klaytn.caver.contract.ContractMethod;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+/**
+ * Representing an ABIWrapper which wraps all of static methods of ABI
+ */
+public class ABIWrapper {
+    /**
+     * Creates an ABIWrapper instance
+     */
+    public ABIWrapper() {
+    }
+
+    /**
+     * Encodes a function call.
+     * @param method A ContractMethod instance.
+     * @param params A List of method parameter.
+     * @return String
+     */
+    public String encodeFunctionCall(ContractMethod method, List<Object> params) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        return ABI.encodeFunctionCall(method, params);
+    }
+
+    /**
+     * Encodes a function call.
+     * @param functionSig A function signature string.
+     * @param params A List of method parameter.
+     * @return String
+     */
+    public String encodeFunctionCall(String functionSig, List<String> solTypeList, List<Object> params) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        return ABI.encodeFunctionCall(functionSig, solTypeList, params);
+    }
+
+    /**
+     * Encodes a function call
+     * @param method A ContractMethod instance.
+     * @param params A List of method parameter wrapped solidity wrapper class.
+     * @return String
+     */
+    public String encodeFunctionCallWithSolidityWrapper(ContractMethod method, List<Type> params) {
+        return ABI.encodeFunctionCallWithSolidityWrapper(method, params);
+    }
+
+    /**
+     * Encodes a function signature.
+     * @param method A ContractMethod instance.
+     * @return String
+     */
+    public String encodeFunctionSignature(ContractMethod method) {
+        return ABI.encodeFunctionSignature(method);
+    }
+
+    /**
+     * Encodes a function signature.
+     * @param functionName A function name string.
+     * @return String
+     */
+    public String encodeFunctionSignature(String functionName) {
+        return ABI.encodeFunctionSignature(functionName);
+    }
+
+    /**
+     * Encodes a data related contract deployment.
+     * @param constructor A ContractMethod instance that contains constructor info.
+     * @param byteCode A smart contract bytecode.
+     * @param constructorParams A list of parameter that need to execute Constructor
+     * @return String
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public String encodeContractDeploy(ContractMethod constructor, String byteCode, List<Object> constructorParams) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        return ABI.encodeContractDeploy(constructor, byteCode, constructorParams);
+    }
+
+    /**
+     * Build a function name string.
+     * @param method A ContractMethod instance.
+     * @return String
+     */
+    public String buildFunctionString(ContractMethod method) {
+        return ABI.buildFunctionString(method);
+    }
+
+    /**
+     * Encodes a event signature.
+     * @param event A ContractEvent instance.
+     * @return String
+     */
+    public String encodeEventSignature(ContractEvent event) {
+        return ABI.encodeEventSignature(event);
+    }
+
+    /**
+     * Encodes a event signature.
+     * @param eventName A event signature.
+     * @return String
+     */
+    public String encodeEventSignature(String eventName) {
+        return ABI.encodeEventSignature(eventName);
+    }
+
+
+    /**
+     * Build a event name string.
+     * @param event A ContractEvent instance
+     * @return String
+     */
+    public String buildEventString(ContractEvent event) {
+        return ABI.buildEventString(event);
+    }
+
+    /**
+     * Encodes a parameter based on its type to its ABI representation.
+     * @param solidityType A solidity type to encode.
+     * @param value A value to encode
+     * @return String
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public String encodeParameter(String solidityType, Object value) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        return ABI.encodeParameter(solidityType, value);
+    }
+
+    /**
+     * Encodes a parameters based on its type to its ABI representation.
+     * @param method A ContractMethod instance that contains to solidity type
+     * @param values A List of value to encode
+     * @return String
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    public String encodeParameters(ContractMethod method, List<Object> values) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        return ABI.encodeParameters(method, values);
+    }
+
+
+    /**
+     * Encodes a parameters based on its type to its ABI representation.
+     * @param solidityTypes A list of solidity type to encode
+     * @param values A List of value to encode
+     * @return String
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public String encodeParameters(List<String> solidityTypes, List<Object> values) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        return ABI.encodeParameters(solidityTypes, values);
+    }
+
+    /**
+     * Encodes a parameter based on its type to its ABI representation.
+     * @param parameter A parameter that wrapped solidity type wrapper.
+     * @return String
+     */
+    public String encodeParameter(Type parameter) {
+        return ABI.encodeParameter(parameter);
+    }
+
+    /**
+     * Encodes a parameter based on its type to its ABI representation.
+     * @param parameters A List of parameters that wrappped solidity type wrapper
+     * @return String
+     */
+    public String encodeParameters(List<Type> parameters) {
+        return ABI.encodeParameters(parameters);
+    }
+
+    /**
+     * Decodes a ABI encoded parameter.
+     * @param solidityType A solidity type string.
+     * @param encoded The ABI byte code to decode
+     * @return Type
+     * @throws ClassNotFoundException
+     */
+    public Type decodeParameter(String solidityType, String encoded) throws ClassNotFoundException {
+        return ABI.decodeParameter(solidityType, encoded);
+    }
+
+    /**
+     * Decodes a ABI encoded parameters.
+     * @param solidityTypeList A List of solidity type string.
+     * @param encoded The ABI byte code to decode
+     * @return List
+     * @throws ClassNotFoundException
+     */
+    public List<Type> decodeParameters(List<String> solidityTypeList, String encoded) throws ClassNotFoundException {
+        return ABI.decodeParameters(solidityTypeList, encoded);
+    }
+
+    /**
+     * Decodes a ABI encoded parameters.
+     * @param method A ContractMethod instance.
+     * @param encoded The ABI byte code to decoed
+     * @return List
+     * @throws ClassNotFoundException
+     */
+    public List<Type> decodeParameters(ContractMethod method, String encoded) throws ClassNotFoundException {
+        return ABI.decodeParameters(method, encoded);
+    }
+
+    /**
+     * Decodes a ABI-encoded log data and indexed topic data
+     * @param inputs A list of ContractIOType instance.
+     * @param data An ABI-encoded in the data field of a log
+     * @param topics A list of indexed parameter topics of the log.
+     * @return EventValues
+     * @throws ClassNotFoundException
+     */
+    public EventValues decodeLog(List<ContractIOType> inputs, String data, List<String> topics) throws ClassNotFoundException {
+        return ABI.decodeLog(inputs, data, topics);
+    }
+}

--- a/core/src/test/java/com/klaytn/caver/common/ABITest.java
+++ b/core/src/test/java/com/klaytn/caver/common/ABITest.java
@@ -1,12 +1,11 @@
 package com.klaytn.caver.common;
 
 import com.klaytn.caver.Caver;
-import com.klaytn.caver.abi.ABI;
-import com.klaytn.caver.abi.TypeDecoder;
-import com.klaytn.caver.contract.Contract;
 import com.klaytn.caver.abi.EventValues;
+import com.klaytn.caver.abi.TypeDecoder;
 import com.klaytn.caver.abi.datatypes.*;
 import com.klaytn.caver.abi.datatypes.generated.*;
+import com.klaytn.caver.contract.Contract;
 import com.klaytn.caver.contract.ContractIOType;
 import org.junit.Test;
 
@@ -14,18 +13,20 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class ABITest {
-
+    static Caver caver = new Caver(Caver.DEFAULT_URL);
     public static class encodeFunctionSig {
         @Test
         public void encodeFunctionSignatureTest() {
-            assertEquals("0xcdcd77c0", ABI.encodeFunctionSignature("baz(uint32,bool)"));
-            assertEquals("0xfce353f6", ABI.encodeFunctionSignature("bar(bytes3[2])"));
-            assertEquals("0xa5643bf2", ABI.encodeFunctionSignature("sam(bytes,bool,uint256[])"));
+            assertEquals("0xcdcd77c0", caver.abi.encodeFunctionSignature("baz(uint32,bool)"));
+            assertEquals("0xfce353f6", caver.abi.encodeFunctionSignature("bar(bytes3[2])"));
+            assertEquals("0xa5643bf2", caver.abi.encodeFunctionSignature("sam(bytes,bool,uint256[])"));
         }
     }
 
@@ -34,11 +35,11 @@ public class ABITest {
         public void encodeEventSignature() {
             assertEquals(
                     ("0x50cb9fe53daa9737b786ab3646f04d0150dc50ef4e75f59509d83667ad5adb20"),
-                    ABI.encodeEventSignature("Deposit(address,hash256,uint256)"));
+                    caver.abi.encodeEventSignature("Deposit(address,hash256,uint256)"));
 
             assertEquals(
                     ("0x71e71a8458267085d5ab16980fd5f114d2d37f232479c245d523ce8d23ca40ed"),
-                    ABI.encodeEventSignature("Notify(uint256,uint256)"));
+                    caver.abi.encodeEventSignature("Notify(uint256,uint256)"));
 
         }
     }
@@ -53,7 +54,7 @@ public class ABITest {
             List<String> typeList = Arrays.asList("uint32", "bool");
             List<Object> params = Arrays.asList(69, true);
 
-            assertEquals(expected, ABI.encodeFunctionCall(functionSig, typeList, params));
+            assertEquals(expected, caver.abi.encodeFunctionCall(functionSig, typeList, params));
         }
 
         @Test
@@ -66,7 +67,7 @@ public class ABITest {
             params.add(new byte[][] {"abc".getBytes(), "def".getBytes()});
 
 
-            assertEquals(expected, ABI.encodeFunctionCall(functionSig, typeList, params));
+            assertEquals(expected, caver.abi.encodeFunctionCall(functionSig, typeList, params));
         }
 
         @Test
@@ -81,75 +82,75 @@ public class ABITest {
                     new BigInteger[] {BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3)}
             );
 
-            assertEquals(expected, ABI.encodeFunctionCall(functionSig, typeList, params));
+            assertEquals(expected, caver.abi.encodeFunctionCall(functionSig, typeList, params));
         }
     }
 
     public static class encodeParameter {
 
         public void encodeParamTest(String params, Object object, String expected) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-            assertEquals(expected, ABI.encodeParameter(params, object));
+            assertEquals(expected, caver.abi.encodeParameter(params, object));
         }
 
         public void encodeParametersTest(List<String> params, List<Object> objects, String expected) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-            assertEquals(expected, ABI.encodeParameters(params, objects));
+            assertEquals(expected, caver.abi.encodeParameters(params, objects));
         }
 
         @Test
         public void encodeBoolType() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
             assertEquals("0000000000000000000000000000000000000000000000000000000000000000",
-                    ABI.encodeParameter("bool", false));
+                    caver.abi.encodeParameter("bool", false));
 
             assertEquals("0000000000000000000000000000000000000000000000000000000000000001",
-                    ABI.encodeParameter("bool", true));
+                    caver.abi.encodeParameter("bool", true));
         }
 
         @Test
         public void encodeUintType() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
             assertEquals("00000000000000000000000000000000000000000000000000000000000000ff",
-                    ABI.encodeParameter("uint", BigInteger.valueOf(255)));
+                    caver.abi.encodeParameter("uint", BigInteger.valueOf(255)));
 
             assertEquals(
                     "000000000000000000000000000000000000000000000000000000000000ffff",
-                    ABI.encodeParameter("uint", BigInteger.valueOf(65535)));
+                    caver.abi.encodeParameter("uint", BigInteger.valueOf(65535)));
 
             assertEquals(
                     "0000000000000000000000000000000000000000000000000000000000010000",
-                    ABI.encodeParameter("uint", BigInteger.valueOf(65536)));
+                    caver.abi.encodeParameter("uint", BigInteger.valueOf(65536)));
 
             assertEquals(
                     "0000000000000000000000000000000000000000000000ffffffffffffffffff",
-                    ABI.encodeParameter("uint", new BigInteger("4722366482869645213695")));
+                    caver.abi.encodeParameter("uint", new BigInteger("4722366482869645213695")));
 
             assertEquals(
                     "0000000000000000000000000000000000000000000000000000000000000000",
-                    ABI.encodeParameter("uint", BigInteger.ZERO));
+                    caver.abi.encodeParameter("uint", BigInteger.ZERO));
         }
 
         @Test
         public void encodeIntType() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
             assertEquals(
                     ("0000000000000000000000000000000000000000000000000000000000000000"),
-                    ABI.encodeParameter("int", BigInteger.ZERO));
+                    caver.abi.encodeParameter("int", BigInteger.ZERO));
 
             assertEquals(
                     ("000000000000000000000000000000000000000000000000000000000000007f"),
-                    ABI.encodeParameter("int", 127));
+                    caver.abi.encodeParameter("int", 127));
 
             assertEquals(
                     ("0000000000000000000000000000000000000000000000000000000000007fff"),
-                    ABI.encodeParameter("int", 32767));
+                    caver.abi.encodeParameter("int", 32767));
 
             assertEquals(
                     ("000000000000000000000000000000000000000000000000000000007fffffff"),
-                    ABI.encodeParameter("int", 2147483647));
+                    caver.abi.encodeParameter("int", 2147483647));
         }
 
         @Test
         public void encodeAddressType() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
             assertEquals(
                     ("000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
-                    ABI.encodeParameter("address", "0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"));
+                    caver.abi.encodeParameter("address", "0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338"));
         }
 
         @Test
@@ -158,25 +159,25 @@ public class ABITest {
                     ("0000000000000000000000000000000000000000000000000000000000000020"
                             + "000000000000000000000000000000000000000000000000000000000000000d"
                             + "48656c6c6f2c20776f726c642100000000000000000000000000000000000000"),
-                    ABI.encodeParameter("string", "Hello, world!"));
+                    caver.abi.encodeParameter("string", "Hello, world!"));
         }
 
         @Test
         public void encodeStaticBytesType() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
             assertEquals("0001020304050000000000000000000000000000000000000000000000000000",
-                    ABI.encodeParameter("bytes6", new byte[] {0, 1, 2, 3, 4, 5}));
+                    caver.abi.encodeParameter("bytes6", new byte[] {0, 1, 2, 3, 4, 5}));
 
             assertEquals(
                     ("0000000000000000000000000000000000000000000000000000000000000000"),
-                    ABI.encodeParameter("bytes1", new byte[] {0}));
+                    caver.abi.encodeParameter("bytes1", new byte[] {0}));
 
             assertEquals(
                     ("7f00000000000000000000000000000000000000000000000000000000000000"),
-                    ABI.encodeParameter("bytes1", new byte[] {127}));
+                    caver.abi.encodeParameter("bytes1", new byte[] {127}));
 
             assertEquals(
                     ("6461766500000000000000000000000000000000000000000000000000000000"),
-                    ABI.encodeParameter("bytes4", "dave".getBytes()));
+                    caver.abi.encodeParameter("bytes4", "dave".getBytes()));
         }
 
         @Test
@@ -186,19 +187,19 @@ public class ABITest {
                     ("0000000000000000000000000000000000000000000000000000000000000020"
                         + "0000000000000000000000000000000000000000000000000000000000000006"
                         + "0001020304050000000000000000000000000000000000000000000000000000"),
-                    ABI.encodeParameter("bytes", new byte[] {0,1,2,3,4,5}));
+                    caver.abi.encodeParameter("bytes", new byte[] {0,1,2,3,4,5}));
 
             assertEquals(
                     ("0000000000000000000000000000000000000000000000000000000000000020"
                         + "0000000000000000000000000000000000000000000000000000000000000001"
                         + "0000000000000000000000000000000000000000000000000000000000000000"),
-                    ABI.encodeParameter("bytes", new byte[] {0}));
+                    caver.abi.encodeParameter("bytes", new byte[] {0}));
 
             assertEquals(
                     ("0000000000000000000000000000000000000000000000000000000000000020"
                         + "0000000000000000000000000000000000000000000000000000000000000004"
                         + "6461766500000000000000000000000000000000000000000000000000000000"),
-                    ABI.encodeParameter("bytes", "dave".getBytes()));
+                    caver.abi.encodeParameter("bytes", "dave".getBytes()));
 
 
             byte[] loremIpsum =  ("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
@@ -227,7 +228,7 @@ public class ABITest {
                             + "63616563617420637570696461746174206e6f6e2070726f6964656e742c2073"
                             + "756e7420696e2063756c706120717569206f666669636961206465736572756e"
                             + "74206d6f6c6c697420616e696d20696420657374206c61626f72756d2e000000"),
-                    ABI.encodeParameter("bytes", loremIpsum));
+                    caver.abi.encodeParameter("bytes", loremIpsum));
         }
 
         @Test
@@ -238,14 +239,14 @@ public class ABITest {
                             + "0000000000000000000000000000000000000000000000000000000000000001"
                             + "0000000000000000000000000000000000000000000000000000000000000002"
                             + "0000000000000000000000000000000000000000000000000000000000000003"),
-                    ABI.encodeParameter("uint256[]", new BigInteger[] {BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3)}));
+                    caver.abi.encodeParameter("uint256[]", new BigInteger[] {BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3)}));
         }
 
         @Test
         public void encodeStaticArrayTest() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
             assertEquals("000000000000000000000000000000000000000000000000000000000000000a"
                     + "0000000000000000000000000000000000000000000000007fffffffffffffff",
-                    ABI.encodeParameter("uint256[2]", new BigInteger[] {BigInteger.valueOf(10), BigInteger.valueOf(Long.MAX_VALUE)}));
+                    caver.abi.encodeParameter("uint256[2]", new BigInteger[] {BigInteger.valueOf(10), BigInteger.valueOf(Long.MAX_VALUE)}));
         }
 
         @Test
@@ -1292,11 +1293,11 @@ public class ABITest {
 
     public static class decodeParameter {
         public void decodeParameterTest(String type, Object expectedValue, String value) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-            assertEquals(TypeDecoder.instantiateType(type, expectedValue), ABI.decodeParameter(type, value));
+            assertEquals(TypeDecoder.instantiateType(type, expectedValue), caver.abi.decodeParameter(type, value));
         }
 
         public void decodeParametersTest(List<String> type, List<Object> expectedValue, String value) throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
-            List<Type> resultList = ABI.decodeParameters(type, value);
+            List<Type> resultList = caver.abi.decodeParameters(type, value);
             for(int i=0; i<type.size(); i++) {
                 assertEquals(TypeDecoder.instantiateType(type.get(i), expectedValue.get(i)), resultList.get(i));
             }
@@ -1306,10 +1307,10 @@ public class ABITest {
         @Test
         public void decodeBoolType() throws ClassNotFoundException {
             assertEquals(
-                    ABI.decodeParameter("bool", "0000000000000000000000000000000000000000000000000000000000000000"),
+                    caver.abi.decodeParameter("bool", "0000000000000000000000000000000000000000000000000000000000000000"),
                     (new Bool(false)));
             assertEquals(
-                    ABI.decodeParameter("bool", "0000000000000000000000000000000000000000000000000000000000000001"),
+                    caver.abi.decodeParameter("bool", "0000000000000000000000000000000000000000000000000000000000000001"),
                     (new Bool(true)));
         }
 
@@ -1317,29 +1318,29 @@ public class ABITest {
         public void decodeUintType() throws ClassNotFoundException {
             Uint uint = new Uint256(BigInteger.valueOf(255));
             assertEquals(
-                    ABI.decodeParameter("uint256", "00000000000000000000000000000000000000000000000000000000000000ff"),
+                    caver.abi.decodeParameter("uint256", "00000000000000000000000000000000000000000000000000000000000000ff"),
                     uint);
 
 
             Uint uint2 = new Uint256(BigInteger.valueOf(65535));
             assertEquals(
-                    ABI.decodeParameter("uint256", "000000000000000000000000000000000000000000000000000000000000ffff"),
+                    caver.abi.decodeParameter("uint256", "000000000000000000000000000000000000000000000000000000000000ffff"),
                     uint2
             );
 
             Uint uint3 = new Uint256(BigInteger.valueOf(65536));
             assertEquals(
-                    ABI.decodeParameter("uint256", "0000000000000000000000000000000000000000000000000000000000010000"),
+                    caver.abi.decodeParameter("uint256", "0000000000000000000000000000000000000000000000000000000000010000"),
                     uint3);
 
             Uint uint4 = new Uint256(new BigInteger("4722366482869645213695"));
             assertEquals(
-                    ABI.decodeParameter("uint256", "0000000000000000000000000000000000000000000000ffffffffffffffffff"),
+                    caver.abi.decodeParameter("uint256", "0000000000000000000000000000000000000000000000ffffffffffffffffff"),
                     uint4);
 
             Uint uint5 = new Uint256(BigInteger.ZERO);
             assertEquals(
-                    ABI.decodeParameter("uint256", "0000000000000000000000000000000000000000000000000000000000000000"),
+                    caver.abi.decodeParameter("uint256", "0000000000000000000000000000000000000000000000000000000000000000"),
                     uint5
                     );
         }
@@ -1348,22 +1349,22 @@ public class ABITest {
         public void decodeIntType() throws ClassNotFoundException {
             Int int1 = new Int256(BigInteger.ZERO);
             assertEquals(
-                    ABI.decodeParameter("int256", "0000000000000000000000000000000000000000000000000000000000000000"),
+                    caver.abi.decodeParameter("int256", "0000000000000000000000000000000000000000000000000000000000000000"),
                     int1);
 
             Int int2 = new Int256(BigInteger.valueOf(127));
             assertEquals(
-                    ABI.decodeParameter("int256", "000000000000000000000000000000000000000000000000000000000000007f"),
+                    caver.abi.decodeParameter("int256", "000000000000000000000000000000000000000000000000000000000000007f"),
                     int2);
 
             Int int3 = new Int256(BigInteger.valueOf(32767));
             assertEquals(
-                    ABI.decodeParameter("int256", "0000000000000000000000000000000000000000000000000000000000007fff"),
+                    caver.abi.decodeParameter("int256", "0000000000000000000000000000000000000000000000000000000000007fff"),
                     int3);
 
             Int int4 = new Int256(BigInteger.valueOf(2147483647));
             assertEquals(
-                    ABI.decodeParameter("int256","000000000000000000000000000000000000000000000000000000007fffffff"),
+                    caver.abi.decodeParameter("int256","000000000000000000000000000000000000000000000000000000007fffffff"),
                     int4);
         }
 
@@ -1371,7 +1372,7 @@ public class ABITest {
         public void decodeAddressType() throws ClassNotFoundException {
             Address address = new Address("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338");
             assertEquals(
-                    ABI.decodeParameter("address","000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
+                    caver.abi.decodeParameter("address","000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338"),
                     address);
         }
 
@@ -1379,7 +1380,7 @@ public class ABITest {
         public void decodeUtf8StringType() throws ClassNotFoundException {
             Utf8String string = new Utf8String("Hello, world!");
             assertEquals(
-                    ABI.decodeParameter("string",
+                    caver.abi.decodeParameter("string",
                             "0000000000000000000000000000000000000000000000000000000000000020"
                             + "000000000000000000000000000000000000000000000000000000000000000d"
                             + "48656c6c6f2c20776f726c642100000000000000000000000000000000000000"),
@@ -1390,22 +1391,22 @@ public class ABITest {
         public void decodeStaticBytesType() throws ClassNotFoundException {
             Bytes staticBytes = new Bytes6(new byte[] {0, 1, 2, 3, 4, 5});
             assertEquals(
-                    ABI.decodeParameter("bytes6", "0001020304050000000000000000000000000000000000000000000000000000"),
+                    caver.abi.decodeParameter("bytes6", "0001020304050000000000000000000000000000000000000000000000000000"),
                     staticBytes);
 
             Bytes empty = new Bytes1(new byte[] {0});
             assertEquals(
-                    ABI.decodeParameter("bytes1", "0000000000000000000000000000000000000000000000000000000000000000"),
+                    caver.abi.decodeParameter("bytes1", "0000000000000000000000000000000000000000000000000000000000000000"),
                     empty);
 
             Bytes ones = new Bytes1(new byte[] {127});
             assertEquals(
-                    ABI.decodeParameter("bytes1", "7f00000000000000000000000000000000000000000000000000000000000000"),
+                    caver.abi.decodeParameter("bytes1", "7f00000000000000000000000000000000000000000000000000000000000000"),
                     ones);
 
             Bytes dave = new Bytes4("dave".getBytes());
             assertEquals(
-                    ABI.decodeParameter("bytes4", "6461766500000000000000000000000000000000000000000000000000000000"),
+                    caver.abi.decodeParameter("bytes4", "6461766500000000000000000000000000000000000000000000000000000000"),
                     dave);
         }
 
@@ -1413,7 +1414,7 @@ public class ABITest {
         public void decodeDynamicBytesType() throws ClassNotFoundException {
             DynamicBytes dynamicBytes = new DynamicBytes(new byte[] {0, 1, 2, 3, 4, 5});
             assertEquals(
-                    ABI.decodeParameter("bytes",
+                    caver.abi.decodeParameter("bytes",
                             "0000000000000000000000000000000000000000000000000000000000000020"
                                     + "0000000000000000000000000000000000000000000000000000000000000006"
                                     + "0001020304050000000000000000000000000000000000000000000000000000"),
@@ -1421,7 +1422,7 @@ public class ABITest {
 
             DynamicBytes empty = new DynamicBytes(new byte[] {0});
             assertEquals(
-                    ABI.decodeParameter("bytes",
+                    caver.abi.decodeParameter("bytes",
                             "0000000000000000000000000000000000000000000000000000000000000020"
                             +"0000000000000000000000000000000000000000000000000000000000000001"
                             + "0000000000000000000000000000000000000000000000000000000000000000"),
@@ -1429,7 +1430,7 @@ public class ABITest {
 
             DynamicBytes dave = new DynamicBytes("dave".getBytes());
             assertEquals(
-                    ABI.decodeParameter("bytes",
+                    caver.abi.decodeParameter("bytes",
                             "0000000000000000000000000000000000000000000000000000000000000020"
                             +"0000000000000000000000000000000000000000000000000000000000000004"
                             + "6461766500000000000000000000000000000000000000000000000000000000"),
@@ -1446,7 +1447,7 @@ public class ABITest {
                                     + "deserunt mollit anim id est laborum.")
                                     .getBytes());
             assertEquals(
-                    ABI.decodeParameter("bytes",
+                    caver.abi.decodeParameter("bytes",
                             "0000000000000000000000000000000000000000000000000000000000000020"
                             +"00000000000000000000000000000000000000000000000000000000000001bd"
                             + "4c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e73"
@@ -1476,7 +1477,7 @@ public class ABITest {
                             new Uint256(BigInteger.valueOf(3)));
 
             assertEquals(
-                    ABI.decodeParameter("uint256[]",
+                    caver.abi.decodeParameter("uint256[]",
                             "0000000000000000000000000000000000000000000000000000000000000020"
                             + "0000000000000000000000000000000000000000000000000000000000000003"
                             + "0000000000000000000000000000000000000000000000000000000000000001"
@@ -1488,7 +1489,7 @@ public class ABITest {
         @Test
         public void decodeStaticArrayTest() throws ClassCastException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
             StaticArray2 expected = new StaticArray2(Uint256.class, Arrays.asList(BigInteger.TEN, BigInteger.valueOf(Long.MAX_VALUE)));
-            StaticArray2 actual = (StaticArray2)ABI.decodeParameter("uint256[2]",
+            StaticArray2 actual = (StaticArray2)caver.abi.decodeParameter("uint256[2]",
                     "000000000000000000000000000000000000000000000000000000000000000a"
                             + "0000000000000000000000000000000000000000000000007fffffffffffffff");
 
@@ -2414,7 +2415,7 @@ public class ABITest {
             BigInteger decimals = BigInteger.valueOf(18);
             BigInteger value = BigInteger.valueOf(100_000).multiply(BigInteger.TEN.pow(decimals.intValue())); // 100000 * 10^18
 
-            EventValues eventValues = ABI.decodeLog(ioTypeList, nonIndexedData, topics);
+            EventValues eventValues = caver.abi.decodeLog(ioTypeList, nonIndexedData, topics);
 
             assertEquals(eventValues.getIndexedValues().get(0).getValue(), "0x0000000000000000000000000000000000000000");
             assertEquals(eventValues.getIndexedValues().get(1).getValue(), "0x2c8ad0ea2e0781db8b8c9242e07de3a5beabb71a");
@@ -2426,7 +2427,7 @@ public class ABITest {
         String TEST_ABI = "[{\"constant\":false,\"inputs\":[{\"name\":\"a\",\"type\":\"bytes32[]\"}],\"name\":\"h\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"a\",\"type\":\"uint256\"},{\"name\":\"b\",\"type\":\"uint256[]\"},{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"y\",\"type\":\"uint256\"}],\"name\":\"c\",\"type\":\"tuple[]\"}],\"name\":\"d\",\"type\":\"tuple[]\"}],\"name\":\"structArray\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"y\",\"type\":\"uint256\"}],\"name\":\"s\",\"type\":\"tuple\"}],\"name\":\"staticStruct\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"s\",\"type\":\"string\"}],\"name\":\"d\",\"type\":\"tuple\"}],\"name\":\"dynamicStruct\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"a\",\"type\":\"uint256\"}],\"name\":\"g\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"a\",\"type\":\"string\"}],\"name\":\"b\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"components\":[{\"name\":\"x\",\"type\":\"uint256\"},{\"name\":\"y\",\"type\":\"uint256\"}],\"indexed\":true,\"name\":\"t\",\"type\":\"tuple\"}],\"name\":\"STRUCT_EVENT\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"t\",\"type\":\"uint256\"}],\"name\":\"EVENT\",\"type\":\"event\"}]";
 
 //        pragma solidity >=0.4.19 <0.7.0;
-//        pragma experimental ABIEncoderV2;
+//        pragma experimental caver.abiEncoderV2;
 //
 //        contract Test {
 //            event STRUCT_EVENT(T indexed t);
@@ -2445,16 +2446,15 @@ public class ABITest {
 //        }
         @Test
         public void buildFunctionStringTest() throws IOException {
-            Caver caver = new Caver(Caver.DEFAULT_URL);
             Contract contract = new Contract(caver, TEST_ABI);
 
-            assertEquals("b(string)", ABI.buildFunctionString(contract.getMethod("b")));
-            assertEquals("g(uint256)", ABI.buildFunctionString(contract.getMethod("g")));
-            assertEquals("h(bytes32[])", ABI.buildFunctionString(contract.getMethod("h")));
+            assertEquals("b(string)", caver.abi.buildFunctionString(contract.getMethod("b")));
+            assertEquals("g(uint256)", caver.abi.buildFunctionString(contract.getMethod("g")));
+            assertEquals("h(bytes32[])", caver.abi.buildFunctionString(contract.getMethod("h")));
 
-            assertEquals("staticStruct((uint256,uint256))", ABI.buildFunctionString(contract.getMethod("staticStruct")));
-            assertEquals("dynamicStruct((uint256,string))", ABI.buildFunctionString(contract.getMethod("dynamicStruct")));
-            assertEquals("structArray((uint256,uint256[],(uint256,uint256)[])[])", ABI.buildFunctionString(contract.getMethod("structArray")));
+            assertEquals("staticStruct((uint256,uint256))", caver.abi.buildFunctionString(contract.getMethod("staticStruct")));
+            assertEquals("dynamicStruct((uint256,string))", caver.abi.buildFunctionString(contract.getMethod("dynamicStruct")));
+            assertEquals("structArray((uint256,uint256[],(uint256,uint256)[])[])", caver.abi.buildFunctionString(contract.getMethod("structArray")));
         }
 
         @Test
@@ -2462,8 +2462,8 @@ public class ABITest {
             Caver caver = new Caver(Caver.DEFAULT_URL);
             Contract contract = new Contract(caver, TEST_ABI);
 
-            assertEquals("EVENT(uint256)", ABI.buildEventString(contract.getEvent("EVENT")));
-            assertEquals("STRUCT_EVENT((uint256,uint256))", ABI.buildEventString(contract.getEvent("STRUCT_EVENT")));
+            assertEquals("EVENT(uint256)", caver.abi.buildEventString(contract.getEvent("EVENT")));
+            assertEquals("STRUCT_EVENT((uint256,uint256))", caver.abi.buildEventString(contract.getEvent("STRUCT_EVENT")));
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR is for improving SDK usability of ABI Layer in [Common Architecture](https://kips.klaytn.com/KIPs/kip-34).

Improving SDK usability means providing users with a similar development experience
 no matter what programming language the SDK is implemented in.

Each layer declared in Common Architecture should be accessed via `caver.`
`ABI` Layer in Common Architecture should be accessed via `caver.abi`.

In caver-js, encoding parameters is done by calling `caver.abi.encodeParameters()`.

To make similar development experiences in caver-java, **I added an ABIWrapper class and add this as a member variable of Caver**

`ABIWrapper` wraps all static methods of ABI class.
As adding this, we can use all static methods of ABI class via `caver.abi`

e.g., `caver.abi.encodeFunctionCall()`, `caver.abi.encodeFunctionCallWithSolidityWrapper()`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
