### PR TITLE
Added an IPFSWrapper

### DIFF
--- a/core/src/main/java/com/klaytn/caver/Caver.java
+++ b/core/src/main/java/com/klaytn/caver/Caver.java
@@ -19,7 +19,7 @@ package com.klaytn.caver;
 import com.klaytn.caver.abi.ABIWrapper;
 import com.klaytn.caver.account.AccountWrapper;
 import com.klaytn.caver.contract.ContractWrapper;
-import com.klaytn.caver.ipfs.IPFS;
+import com.klaytn.caver.ipfs.IPFSWrapper;
 import com.klaytn.caver.kct.KCTWrapper;
 import com.klaytn.caver.rpc.RPC;
 import com.klaytn.caver.transaction.TransactionWrapper;
@@ -69,7 +69,7 @@ public class Caver {
     /**
      * The IPFS instance.
      */
-    public IPFS ipfs;
+    public IPFSWrapper ipfs;
 
     /**
      * The AccountWrapper instance
@@ -117,7 +117,7 @@ public class Caver {
      * @param service Web3jService
      */
     public Caver(Web3jService service) {
-        ipfs = new IPFS();
+        ipfs = new IPFSWrapper();
         rpc = new RPC(service);
         wallet = new KeyringContainer();
         account = new AccountWrapper();
@@ -169,10 +169,10 @@ public class Caver {
     }
 
     /**
-     * Getter for IPFS
-     * @return IPFS
+     * Getter for IPFSWrapper
+     * @return IPFSWrapper
      */
-    public IPFS getIpfs() {
+    public IPFSWrapper getIpfs() {
         return ipfs;
     }
 

--- a/core/src/main/java/com/klaytn/caver/Caver.java
+++ b/core/src/main/java/com/klaytn/caver/Caver.java
@@ -67,7 +67,7 @@ public class Caver {
     public TransactionWrapper transaction;
 
     /**
-     * The IPFS instance.
+     * The IPFSWrapper instance.
      */
     public IPFSWrapper ipfs;
 

--- a/core/src/main/java/com/klaytn/caver/ipfs/IPFSWrapper.java
+++ b/core/src/main/java/com/klaytn/caver/ipfs/IPFSWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 The caver-java Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.klaytn.caver.ipfs;
+
+import java.io.IOException;
+
+/**
+ * Representing an IPFSWrapper
+ * 1. This class should be accessed through `caver.ipfs`
+ * 2. This class wraps all public methods (including static methods) of IPFS
+ */
+public class IPFSWrapper {
+    /**
+     * The IPFS instance
+     */
+    private IPFS ipfs;
+
+    /**
+     * Creates an IPFSWrapper instance
+     */
+    public IPFSWrapper() {
+        this.ipfs = new IPFS();
+    }
+
+    /**
+     * Decode encoded multi hash string with Base58 and add hex prefix(0x).
+     * @param encodedHash A encoded string with Base58.
+     * @return String
+     */
+    public String toHex(String encodedHash) {
+        return IPFS.toHex(encodedHash);
+    }
+
+    /**
+     * Encode hex string with Base58 algorithm.
+     * @param hexString A hex string to encode.
+     * @return String
+     */
+    public String fromHex(String hexString) {
+        return IPFS.fromHex(hexString);
+    }
+
+    /**
+     * Add file to IPFS.
+     * @param path A file path to add at IPFS.
+     * @return String
+     * @throws IOException
+     */
+    public String add(String path) throws IOException {
+        return this.ipfs.add(path);
+    }
+
+    /**
+     * Add byte array to IPFS
+     * @param content A byte array to add at IPFS
+     * @return String
+     * @throws IOException
+     */
+    public String add(byte[] content) throws IOException {
+        return this.ipfs.add(content);
+    }
+
+    /**
+     * Get file from IPFS.
+     * @param encodedHash A encoded multi hash string with base58.
+     * @return byte[]
+     * @throws IOException
+     */
+    public byte[] get(String encodedHash) throws IOException {
+        return this.ipfs.get(encodedHash);
+    }
+
+    /**
+     * Set a IPFS node.
+     * @param host The host url.
+     * @param port The port number to use.
+     * @param ssl either using ssl or not.
+     */
+    public void setIPFSNode(String host, int port, boolean ssl) {
+        this.ipfs.setIPFSNode(host, port, ssl);
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR is for improving SDK usability of "IPFS" package.

Improving SDK usability means providing users with a similar development experience
no matter what programming language the SDK is implemented in.

In caver-js, all methods of IPFS class can be called through `caver.ipfs`.  
e.g., `caver.ipfs.fromHex()`, `caver.ipfs.toHex()`.

To make similar development experiences in caver-java,
**I added an `IPFSWrapper` class and make this as a member variable of `Caver` instead of `IPFS`.**

`IPFSWrapper` wraps all methods (including static methods) of IPFS class.
As adding this, we can use all methods of IPFS class via `caver.ipfs`.

e.g., `caver.ipfs.fromHex()`, `caver.ipfs.add()`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
