### PR TITLE
Fix "Duplicated Account" problem caused by `KeyringContainer.remove()`

### DIFF
--- a/core/src/main/java/com/klaytn/caver/wallet/KeyringContainer.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/KeyringContainer.java
@@ -201,7 +201,7 @@ public class KeyringContainer implements IWallet{
             return false;
         }
         //deallocate keyring object created for keyringContainer.
-        AbstractKeyring removed = this.addressKeyringMap.remove(address);
+        AbstractKeyring removed = this.addressKeyringMap.remove(address.toLowerCase());
         removed = null;
 
         return true;

--- a/core/src/test/java/com/klaytn/caver/common/KeyringContainerTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/KeyringContainerTest.java
@@ -9,13 +9,10 @@ import com.klaytn.caver.transaction.type.AccountUpdate;
 import com.klaytn.caver.transaction.type.FeeDelegatedValueTransfer;
 import com.klaytn.caver.transaction.type.ValueTransfer;
 import com.klaytn.caver.utils.Utils;
-import com.klaytn.caver.wallet.KeyringContainer;
 import com.klaytn.caver.wallet.keyring.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -535,6 +532,34 @@ public class KeyringContainerTest {
             assertTrue(result);
             assertEquals(0, caver.wallet.length());
             assertNull(caver.wallet.getKeyring(keyringToAdd.getAddress()));
+        }
+
+        @Test
+        public void keyringWithChecksumAddress() {
+            String checksumAddress = "0xAF00B68464538Ee586b4f20C22b8A4ad28Ac4761";
+            SingleKeyring singleKeyring = caver.wallet.keyring.create(
+                    checksumAddress,
+                    caver.wallet.keyring.generateSingleKey()
+            );
+            caver.wallet.add(singleKeyring);
+            caver.wallet.remove(singleKeyring.getAddress());
+            assertEquals("Should remove singleKeyring having checksum address from caver.wallet", caver.wallet.length() , 0);
+
+            MultipleKeyring multipleKeyring = caver.wallet.keyring.createWithMultipleKey(
+                    checksumAddress,
+                    caver.wallet.keyring.generateMultipleKeys(3)
+            );
+            caver.wallet.add(multipleKeyring);
+            caver.wallet.remove(multipleKeyring.getAddress());
+            assertEquals("Should remove multipleKeyring having checksum address from caver.wallet", caver.wallet.length(), 0);
+
+            RoleBasedKeyring roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
+                    checksumAddress,
+                    caver.wallet.keyring.generateRolBasedKeys(new int[]{2, 2, 1})
+            );
+            caver.wallet.add(roleBasedKeyring);
+            caver.wallet.remove(multipleKeyring.getAddress());
+            assertEquals("Should remove roleBasedKeyring having checksum address from caver.wallet", caver.wallet.length(), 0);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

This PR fix "Duplicated Account" problem caused by `KeyringContainer.remove()`.

Because `Keyring Container.add()` and `Keyring Container.get Keyring()` both use **lower cased address**,
`Keyring Container.remove()` should guarantee its input address is lower cased.

You can re-produce error by following below sequence.
1. Add your keyring to wallet using `caver.wallet.add()` with address having lower and capital letter both. (e.g. `0xca04A7e79072CE7edd3C1B0bFAdDe496806a16AD`)
2. Update your keyring using `caver.wallet.updateKeyring()` with new keyring which have same address in sequence 1 and different private key.
3. Then you can see the error `"Duplicated Account. Please use updateKeyring() instead"`.

Here is the Gist [RemoveErrorTest.java](https://gist.github.com/aeharvlee/5eeb520b944574ed053baff233c746a9) for more detail. You can test yourself with this Gist and [KAS](https://www.klaytnapi.com/)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
