### PR TITLE
Fixed an issue where the sourceCompatibility and targetCompatibility options were not being applied properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,13 +34,13 @@ allprojects {
     version '1.6.1'
     group 'com.klaytn.caver'
     description 'caver-java project'
-
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
 }
 
 configure(allprojects.findAll {it.name != 'android_instrumented_test'}) {
     apply plugin: 'java'
+
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Proposed changes
This PR fixed an issue where the sourceCompatibility and targetCompatibility options were not being applied properly.
To make sourceCompatibility, targetCompatibility works, we need to define it below `apply plugin: 'java'`.

Here is the guide "How to check whether caver-java library is built with JDK 1.8 (= Java 8)"

1. Get into circle ci machine using ssh
2. After build step is finished, move to `/home/circleci/circleci-caver-java-android/core/build/libs`
3. Extract class files from jar using `jar xf core-1.6.1-android.jar`
4. Check which version of JVM is used to compile class files using `javap -verbose /home/circleci/circleci-caver-java-android/core/build/libs/com/klaytn/caver/Caver.class | grep "major"` (You can check another lib like codegen or console like this)

If the result is `major version: 52`, everything is OK.
Below is a version info about Java.

* Java 8 uses major version 52
* Java 9 uses major version 53
* Java 10 uses major version 54
* Java 11 uses major version 55


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
