### PR TITLE
Modified to hashMessage() logic and add a Utils.decodeSignature()

### DIFF
--- a/core/src/main/java/com/klaytn/caver/utils/Utils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/Utils.java
@@ -24,8 +24,11 @@ import org.web3j.crypto.Keys;
 import org.web3j.crypto.Sign;
 import org.web3j.utils.Numeric;
 
+import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.SignatureException;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -406,6 +409,25 @@ public class Utils {
             throw new SignatureException("Could not recover public key from signature");
         }
         return Numeric.prependHexPrefix(Keys.getAddress(key));
+    }
+
+    /**
+     * Decodes a raw signature data that composed of R(32 byte) + S(32 byte) + V(1byte).
+     * @param rawSig A signature data to decode. It composed of R(32 byte) + S(32 byte) + V(1byte).
+     * @return SignatureData
+     */
+    public static SignatureData decodeSignature(String rawSig) {
+        String noPrefixSigData = Utils.stripHexPrefix(rawSig);
+
+        if(noPrefixSigData.length() != 130) {
+            throw new RuntimeException("Invalid signature data. The sig data length must 65 byte.");
+        }
+
+        String r = noPrefixSigData.substring(0, 64);
+        String s = noPrefixSigData.substring(64, 128);
+        String v = noPrefixSigData.substring(128);
+
+        return new SignatureData(v, r, s);
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/utils/Utils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/Utils.java
@@ -197,10 +197,17 @@ public class Utils {
      * @return String
      */
     public static String hashMessage(String message) {
-        final String preamble = "\\x19Klaytn Signed Message:\\n";
+        final String preamble = "\u0019Klaytn Signed Message:\n";
 
-        String klaytnMessage =  preamble + message.length() + message;
-        return Hash.sha3(klaytnMessage);
+        byte[] messageArr = Utils.isHexStrict(message)? Numeric.hexStringToByteArray(message) : message.getBytes();
+        byte[] preambleArr = preamble.concat(String.valueOf(messageArr.length)).getBytes();
+
+        // klayMessage is concatenated array (preambleArr + messageArr)
+        byte[] klayMessage = BytesUtils.concat(preambleArr, messageArr);
+        byte[] result =  Hash.sha3(klayMessage);
+
+        //return data after converting to hex string.
+        return Numeric.toHexString(result);
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/utils/wrapper/UtilsWrapper.java
+++ b/core/src/main/java/com/klaytn/caver/utils/wrapper/UtilsWrapper.java
@@ -294,4 +294,13 @@ public class UtilsWrapper {
     public byte[] generateRandomBytes(int size) {
         return Utils.generateRandomBytes(size);
     }
+
+    /**
+     * Decodes a raw signature data that composed of R(32 byte) + S(32 byte) + V(1byte).
+     * @param rawSig A signature data to decode. It composed of R(32 byte) + S(32 byte) + V(1byte).
+     * @return SignatureData
+     */
+    public SignatureData decodeSignature(String rawSig) {
+        return Utils.decodeSignature(rawSig);
+    }
 }

--- a/core/src/main/java/com/klaytn/caver/wallet/keyring/SignatureData.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/keyring/SignatureData.java
@@ -55,9 +55,9 @@ public class SignatureData {
      * @param s The ECDSA Signature data S
      */
     public SignatureData(String v, String r, String s) {
-        this.v = v;
-        this.r = r;
-        this.s = s;
+        this.v = Utils.addHexPrefix(v);
+        this.r = Utils.addHexPrefix(r);
+        this.s = Utils.addHexPrefix(s);
     }
 
     /**

--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -1055,8 +1055,8 @@ public class UtilsTest {
             String expectedAddress = "0xb6a1f97502431e6f8d701f9e192c3cc43c07351a";
             String message = "Klaytn Test";
 
-            SignatureData signatureData = Utils.decodeSignature(expectedSignedMessage);
-            String actualAddress = Utils.recover(message, signatureData);
+            SignatureData signatureData = caver.utils.decodeSignature(expectedSignedMessage);
+            String actualAddress = caver.utils.recover(message, signatureData);
 
             checkAddress(expectedAddress, actualAddress);
         }
@@ -1067,7 +1067,7 @@ public class UtilsTest {
             String message = "Some data";
 
             MessageSigned signed = keyring.signMessage(message, 0, 0);
-            String actualAddress = Utils.recover(signed.getMessageHash(), signed.getSignatures().get(0), true);
+            String actualAddress = caver.utils.recover(signed.getMessageHash(), signed.getSignatures().get(0), true);
 
             checkAddress(keyring.getAddress(), actualAddress);
         }
@@ -1093,7 +1093,7 @@ public class UtilsTest {
             };
 
             for(int i=0; i < rawSigDataArr.length; i++) {
-                assertEquals(signatureData[i], Utils.decodeSignature(rawSigDataArr[i]));
+                assertEquals(signatureData[i], caver.utils.decodeSignature(rawSigDataArr[i]));
             }
         }
 
@@ -1103,7 +1103,7 @@ public class UtilsTest {
             expectedException.expectMessage("Invalid signature data. The sig data length must 65 byte.");
 
             String rawSigData = "0xaaaaaa";
-            Utils.decodeSignature(rawSigData);
+            caver.utils.decodeSignature(rawSigData);
         }
     }
 }

--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -224,10 +224,23 @@ public class UtilsTest {
     public static class hashMessageTest {
         @Test
         public void hashMessageTest() {
-            String data = "0xdeadbeaf";
-            String actual = caver.utils.hashMessage(data);
-            assertEquals(66, actual.length());
+            String[] message = {"some data", "test data", "caver-java", "sign data", "0xaabbccdd", "0x11223344", "0x33445566"};
+            String[] expected = {
+                    "0x5373135dbda1d8f2eaee73adcc07d03cd3bbc2510b3bfdbd4fcf9de2f34c505e",
+                    "0x416066097cb5808c62e1d7129249b37e661838ed49d6c3347a4a3f290020e952",
+                    "0x096f523188dc1ddc620db4ec828733c0db209491849b85bb6bbd31d1498239cf",
+                    "0x4c4865cee1cda8a2a3130be37a7739324a78ea36f39b18ae7dfecee5e5ce6fa2",
+                    "0x4f8b23edb1db90554d99eb9667a950c78445f5efc6aaccb4d0243ee82f89b475",
+                    "0x18ecf869a4437f5d036af0b25b2cb43362f857e19394e32e148439c99c768d1e",
+                    "0x257527206116286147dd9827b21905add9c42ab16034ae6d6e9c2954199d0f08"
+            };
+
+            for(int i=0; i<message.length; i++) {
+                assertEquals(expected[i], Utils.hashMessage(message[i]));
+            }
         }
+
+
     }
 
     public static class parseKlaytnWalletKeyTest {
@@ -1021,6 +1034,38 @@ public class UtilsTest {
             byte[] arr = caver.utils.generateRandomBytes(32);
 
             assertEquals(32, arr.length);
+        }
+    }
+
+    public static class recoverTest {
+        public void checkAddress(String expect, String actual) {
+            expect = Numeric.prependHexPrefix(expect);
+            actual = Numeric.prependHexPrefix(actual);
+
+            assertEquals(expect, actual);
+        }
+
+        @Test
+        public void withMessageAndSignature() throws SignatureException {
+            String expectedSignedMessage = "0xc69018da9396c4b87947e0784625af7475caf46e2af9cf57a44673ff0f625258642d8993751ae67271bcc131aa065adccf9f16fc4953f9c48f4a80d675c09ae81b";
+            String expectedAddress = "0xb6a1f97502431e6f8d701f9e192c3cc43c07351a";
+            String message = "Klaytn Test";
+
+            SignatureData signatureData = Utils.decodeSignature(expectedSignedMessage);
+            String actualAddress = Utils.recover(message, signatureData);
+
+            checkAddress(expectedAddress, actualAddress);
+        }
+
+        @Test
+        public void alreadyPrefix() throws SignatureException {
+            SingleKeyring keyring = KeyringFactory.generate();
+            String message = "Some data";
+
+            MessageSigned signed = keyring.signMessage(message, 0, 0);
+            String actualAddress = Utils.recover(signed.getMessageHash(), signed.getSignatures().get(0), true);
+
+            checkAddress(keyring.getAddress(), actualAddress);
         }
     }
 }

--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -2,6 +2,8 @@ package com.klaytn.caver.common.utils;
 
 import com.klaytn.caver.Caver;
 import com.klaytn.caver.utils.Utils;
+import com.klaytn.caver.wallet.keyring.KeyringFactory;
+import com.klaytn.caver.wallet.keyring.MessageSigned;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import com.klaytn.caver.wallet.keyring.SingleKeyring;
 import org.junit.Rule;
@@ -9,8 +11,10 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.web3j.utils.Numeric;
 
 import java.math.BigDecimal;
+import java.security.SignatureException;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
@@ -1066,6 +1070,40 @@ public class UtilsTest {
             String actualAddress = Utils.recover(signed.getMessageHash(), signed.getSignatures().get(0), true);
 
             checkAddress(keyring.getAddress(), actualAddress);
+        }
+    }
+
+    public static class decodeSignatureTest {
+
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        @Test
+        public void decodeSignatureTest() {
+            String[] rawSigDataArr = {
+                    "0xc69018da9396c4b87947e0784625af7475caf46e2af9cf57a44673ff0f625258642d8993751ae67271bcc131aa065adccf9f16fc4953f9c48f4a80d675c09ae81b",
+                    "0x4c78ba080e717534772c4a9714b06a12f8d41062fca72885dafa8f1e1d6d78de35a50522df6361d16c05d1368bb9d86da1054f153301d5dedc6658d222616edd1b",
+                    "0xacfc5c417a8506eb1bd8394553fbde4a9097ea854bdbbe0de2bfaebcc9a26f45521773632317323f3d3da09bf06185af1ee0481ef0d1abb8a790f3a110eadfc31c"
+            };
+
+            SignatureData[] signatureData = {
+                    new SignatureData("1b", "c69018da9396c4b87947e0784625af7475caf46e2af9cf57a44673ff0f625258", "642d8993751ae67271bcc131aa065adccf9f16fc4953f9c48f4a80d675c09ae8"),
+                    new SignatureData("1b", "4c78ba080e717534772c4a9714b06a12f8d41062fca72885dafa8f1e1d6d78de", "35a50522df6361d16c05d1368bb9d86da1054f153301d5dedc6658d222616edd"),
+                    new SignatureData("1c", "acfc5c417a8506eb1bd8394553fbde4a9097ea854bdbbe0de2bfaebcc9a26f45", "521773632317323f3d3da09bf06185af1ee0481ef0d1abb8a790f3a110eadfc3")
+            };
+
+            for(int i=0; i < rawSigDataArr.length; i++) {
+                assertEquals(signatureData[i], Utils.decodeSignature(rawSigDataArr[i]));
+            }
+        }
+
+        @Test
+        public void throwException_invalidLength() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Invalid signature data. The sig data length must 65 byte.");
+
+            String rawSigData = "0xaaaaaa";
+            Utils.decodeSignature(rawSigData);
         }
     }
 }

--- a/core/src/test/java/com/klaytn/caver/common/wallet/KeyringTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/wallet/KeyringTest.java
@@ -1187,50 +1187,6 @@ public class KeyringTest {
 //        }
     }
 
-    public static class recoverTest {
-        public void checkAddress(String expect, String actual) {
-            expect = Numeric.prependHexPrefix(expect);
-            actual = Numeric.prependHexPrefix(actual);
-
-            assertEquals(expect, actual);
-        }
-
-        //CA-KEYRING-073
-//        @Test
-//        public void withSignedMessage() throws SignatureException {
-//            SingleKeyring keyring = KeyringFactory.generate();
-//            String message = "Some data";
-//            MessageSigned signed = keyring.signMessage(message, 0, 0);
-//
-//            String actualAddr = Utils.recover(signed);
-//            checkAddress(keyring.getAddress(), actualAddr);
-//        }
-
-        //CA-KEYRING-074
-        @Test
-        public void withMessageAndSignature() throws SignatureException {
-            SingleKeyring keyring = KeyringFactory.generate();
-            String message = "Some data";
-
-            MessageSigned signed = keyring.signMessage(message, 0, 0);
-            String actualAddr = Utils.recover(signed.getMessage(), signed.getSignatures().get(0));
-
-            checkAddress(keyring.getAddress(), actualAddr);
-        }
-
-        //CA-KEYRING-075
-        @Test
-        public void alreadyPrefix() throws SignatureException {
-            SingleKeyring keyring = KeyringFactory.generate();
-            String message = "Some data";
-
-            MessageSigned signed = keyring.signMessage(message, 0, 0);
-            String actualAddr = Utils.recover(signed.getMessageHash(), signed.getSignatures().get(0), true);
-
-            checkAddress(keyring.getAddress(), actualAddr);
-        }
-    }
-
     public static class decryptTest {
 
         String jsonV3 = "{\n" +


### PR DESCRIPTION
## Proposed changes

This PR includes the following
  - Modified to hashMessage() logic
    - Before executing keccack256 hash algorithm, convert a data string to byte array
  - add a Utils.decodeSignature()
    - It decodes a raw sig data composed of R(32) + S(32) + V(1)  

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
