### PR TITLE
Updated circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,7 @@ build_test: &build_test
 
 build_test_android: &build_test_android
   run:
-    name: "Build without unit tests and do instrumented test on Android Emulator"
-    no_output_timeout: 20m
+    name: "Build"
     command: |
       ./gradlew clean
       ./gradlew build --debug -x :android_instrumented_test:build -x test
@@ -185,6 +184,7 @@ jobs:
       - *adb_logging
       - run:
           name: Run instrumented test on android emulator
+          no_output_timeout: 40m
           command: ./gradlew connectedDebugAndroidTest --debug --stacktrace
       - store_test_results:
           path: android_instrumented_test/build/outputs/androidTest-results/connected

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
       - *adb_logging
       - run:
           name: Run instrumented test on android emulator
-          no_output_timeout: 40m
+          no_output_timeout: 20m
           command: ./gradlew connectedDebugAndroidTest --debug --stacktrace
       - store_test_results:
           path: android_instrumented_test/build/outputs/androidTest-results/connected

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ build_test: &build_test
 
 build_test_android: &build_test_android
   run:
-    name: "Build"
+    name: "Build android"
     command: |
       ./gradlew clean
       ./gradlew build --debug -x :android_instrumented_test:build -x test


### PR DESCRIPTION
## Proposed changes
This PR suggests updating `.circleci/config.yaml` like below.

**1. Moved `no_output_timeout` from build_test_android step to instrumented test step**

The `no_output_timeout` option was added to prevent Gradle from sometimes deadlocking during instrumentation tests.

What build_test_android step do now is just building without any tests, we don't have to put it here.

The right place of the option is the step doing instrumented testing on android emulator.

**2. Change name of build_android_test step**
This step does just building, so the name of this step should describe this.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...