### PR TITLE
Separate the library of web3j used in accordance with the project version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext.javapoetVersion = '1.7.0'
     ext.web3jVersion = '4.6.0'
+    ext.web3j_androidVersion = '4.6.0-android'
     ext.picocliVersion = '3.0.0'
     ext.junitVersion = '4.12'
     ext.slf4jVersion = '1.7.25'
@@ -34,6 +35,14 @@ allprojects {
     version '1.6.3'
     group 'com.klaytn.caver'
     description 'caver-java project'
+
+    ext {
+        isAndroidBuild = project.version.endsWith("-android");
+        ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')
+        ossrhPassword = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
+        ossrhSigningKey_base64 = project.hasProperty('signingKey')? project.property('signingKey') : System.getenv('ORG_GRADLE_PROJECT_signingKey')
+        ossrhSigningPassword = project.hasProperty('signingKey')? project.property('signingPassword') : System.getenv('ORG_GRADLE_PROJECT_signingPassword')
+    }
 }
 
 configure(allprojects.findAll {it.name != 'android_instrumented_test'}) {
@@ -71,13 +80,6 @@ configure(subprojects.findAll {it.name != 'integration-test' && it.name != 'andr
     task sourcesJar(type: Jar) {
         archiveClassifier = 'sources'
         from sourceSets.main.allSource
-    }
-
-    ext {
-        ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')
-        ossrhPassword = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
-        ossrhSigningKey_base64 = project.hasProperty('signingKey')? project.property('signingKey') : System.getenv('ORG_GRADLE_PROJECT_signingKey')
-        ossrhSigningPassword = project.hasProperty('signingKey')? project.property('signingPassword') : System.getenv('ORG_GRADLE_PROJECT_signingPassword')
     }
 
     publishing {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,12 @@
 description 'caverj project core'
 
 dependencies {
-    compile "org.web3j:core:$web3jVersion"
+    if(isAndroidBuild) {
+        compile "org.web3j:core:$web3j_androidVersion"
+    } else {
+        compile "org.web3j:core:$web3jVersion"
+    }
+
     compile "com.github.ipfs:java-ipfs-http-client:$ipfsVersion"
 }
 


### PR DESCRIPTION
## Proposed changes

This pr separated the library of web3j used in accordance with the project version
  - If the project version ends with "-android", using web3j-android.
  - else using web3j

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
