### PR TITLE
Fixed typo at method name

### DIFF
--- a/core/src/main/java/com/klaytn/caver/wallet/keyring/KeyringFactory.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/keyring/KeyringFactory.java
@@ -101,7 +101,7 @@ public class KeyringFactory {
      * @param numArr An array containing the number of keys for each role.
      * @return List
      */
-    public static List<String[]> generateRolBasedKeys(int[] numArr) {
+    public static List<String[]> generateRoleBasedKeys(int[] numArr) {
         return generateRoleBasedKeys(numArr, null);
     }
 

--- a/core/src/main/java/com/klaytn/caver/wallet/keyring/wrapper/KeyringFactoryWrapper.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/keyring/wrapper/KeyringFactoryWrapper.java
@@ -91,8 +91,8 @@ public class KeyringFactoryWrapper {
      * @param numArr An array containing the number of keys for each role.
      * @return List
      */
-    public List<String[]> generateRolBasedKeys(int[] numArr) {
-        return KeyringFactory.generateRolBasedKeys(numArr);
+    public List<String[]> generateRoleBasedKeys(int[] numArr) {
+        return KeyringFactory.generateRoleBasedKeys(numArr);
     }
 
     /**

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateTest.java
@@ -760,7 +760,7 @@ public class FeeDelegatedAccountUpdateTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
 
             account = Account.createWithAccountKeyFail(from);

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedAccountUpdateWithRatioTest.java
@@ -874,7 +874,7 @@ public class FeeDelegatedAccountUpdateWithRatioTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
 
             account = Account.createWithAccountKeyFail(from);

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelTest.java
@@ -547,7 +547,7 @@ public class FeeDelegatedCancelTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedCancelWithRatioTest.java
@@ -692,7 +692,7 @@ public class FeeDelegatedCancelWithRatioTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringTest.java
@@ -643,7 +643,7 @@ public class FeeDelegatedChainDataAnchoringTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedChainDataAnchoringWithRatioTest.java
@@ -802,7 +802,7 @@ public class FeeDelegatedChainDataAnchoringWithRatioTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployTest.java
@@ -873,7 +873,7 @@ public class FeeDelegatedSmartContractDeployTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractDeployWithRatioTest.java
@@ -1035,7 +1035,7 @@ public class FeeDelegatedSmartContractDeployWithRatioTest {
 
             singleKeyring = caver.wallet.keyring.createWithSingleKey(feePayer, feePayerPrivateKey);
             multipleKeyring = caver.wallet.keyring.createWithMultipleKey(feePayer, caver.wallet.keyring.generateMultipleKeys(8));
-            roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(feePayer, caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5}));
+            roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(feePayer, caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5}));
         }
 
         @Test

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionTest.java
@@ -824,7 +824,7 @@ public class FeeDelegatedSmartContractExecutionTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedSmartContractExecutionWithRatioTest.java
@@ -1010,7 +1010,7 @@ public class FeeDelegatedSmartContractExecutionWithRatioTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoTest.java
@@ -794,7 +794,7 @@ public class FeeDelegatedValueTransferMemoTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferMemoWithRatioTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 import org.web3j.utils.Numeric;
 
 import java.io.IOException;
@@ -1053,7 +1052,7 @@ public class FeeDelegatedValueTransferMemoWithRatioTest {
 
             singleKeyring = caver.wallet.keyring.createWithSingleKey(feePayer, feePayerPrivateKey);
             multipleKeyring = caver.wallet.keyring.createWithMultipleKey(feePayer, caver.wallet.keyring.generateMultipleKeys(8));
-            roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(feePayer, caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5}));
+            roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(feePayer, caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5}));
         }
 
         @Test

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferTest.java
@@ -766,7 +766,7 @@ public class FeeDelegatedValueTransferTest {
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferWithRatioTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/FeeDelegatedValueTransferWithRatioTest.java
@@ -928,7 +928,7 @@ public class FeeDelegatedValueTransferWithRatioTest {
                     caver.wallet.keyring.generateMultipleKeys(8)
             );
             roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(feePayer,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{3, 4, 5})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{3, 4, 5})
             );
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/wallet/KeyringContainerTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/wallet/KeyringContainerTest.java
@@ -558,7 +558,7 @@ public class KeyringContainerTest {
 
             RoleBasedKeyring roleBasedKeyring = caver.wallet.keyring.createWithRoleBasedKey(
                     checksumAddress,
-                    caver.wallet.keyring.generateRolBasedKeys(new int[]{2, 2, 1})
+                    caver.wallet.keyring.generateRoleBasedKeys(new int[]{2, 2, 1})
             );
             caver.wallet.add(roleBasedKeyring);
             caver.wallet.remove(multipleKeyring.getAddress());


### PR DESCRIPTION
## Proposed changes

This PR fixed typo at method name `generateRolBasedKeys`.
`generateRolBasedKeys` must be named `generateRoleBasedKeys`. 

This method is in both `KeyringFactory.java` and `KeyringFactoryWrapper.java`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
