### PR TITLE
Modified to decode LegacyTransaction type raw transaction.

### DIFF
--- a/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
@@ -168,11 +168,11 @@ public class LegacyTransaction extends AbstractTransaction {
             RlpList rlpList = RlpDecoder.decode(rlpEncoded);
             List<RlpType> values = ((RlpList) rlpList.getValues().get(0)).getValues();
 
-            String nonce = ((RlpString) values.get(0)).asString();
-            String gasPrice = ((RlpString) values.get(1)).asString();
-            String gas = ((RlpString) values.get(2)).asString();
+            BigInteger nonce = ((RlpString) values.get(0)).asPositiveBigInteger();
+            BigInteger gasPrice = ((RlpString) values.get(1)).asPositiveBigInteger();
+            BigInteger gas = ((RlpString) values.get(2)).asPositiveBigInteger();
             String to = ((RlpString) values.get(3)).asString();
-            String value = ((RlpString) values.get(4)).asString();
+            BigInteger value = ((RlpString) values.get(4)).asPositiveBigInteger();
             String input = ((RlpString) values.get(5)).asString();
 
             LegacyTransaction legacyTransaction = new LegacyTransaction.Builder()

--- a/core/src/test/java/com/klaytn/caver/common/transaction/LegacyTransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/LegacyTransactionTest.java
@@ -1300,4 +1300,14 @@ public class LegacyTransactionTest {
             legacyTransaction.appendSignatures(list);
         }
     }
+
+    public static class decodeTest {
+        @Test
+        public void decodeTest() {
+            String rawTx = "0xf868808505d21dba008402faf0809459177716c34ac6e49e295a0e78e33522f14d61ee0180820fe9a0ecdec357060dbbb4bd3790e98b1733ec3a0b02b7e4ec7a5622f93cd9bee229fea00a4a5e28753e7c1d999b286fb07933c5bf353079b8ed4d1ed509a838b48be02c";
+            LegacyTransaction tx = LegacyTransaction.decode(rawTx);
+
+            assertEquals(rawTx, tx.getRawTransaction());
+        }
+    }
 }


### PR DESCRIPTION
## Proposed changes

This PR modified LegacyTransaction's decode logic.
  - If a number type of a field(e.g. nonce, gas, gasPrice, value) has 0 value, It decodes as a bigInteger type.
     -  If the value 0x80(0x00) decodes as a String type, it returns a "0x". So It needs to be a number type.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
