### PR TITLE
added to logic that public key passed as parameter is valid in compressPublicKey and decompressPublicKey.

### DIFF
--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -176,6 +176,9 @@ public class UtilsTest {
     }
 
     public static class decompressPublicKeyTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
         @Test
         public void decompressPublicKey() {
             String compressed = "03434dedfc2eceed1e98fddfde3ebc57512c57f017195988cd5de62b722656b943";
@@ -189,7 +192,7 @@ public class UtilsTest {
             String expectedUncompressed = caver.wallet.keyring.generate().getPublicKey(false);
             String actualUncompressed = caver.utils.decompressPublicKey(expectedUncompressed);
             assertTrue(caver.utils.isValidPublicKey(actualUncompressed));
-            assertEquals(expectedUncompressed, actualUncompressed);
+            assertEquals(caver.utils.addHexPrefix(expectedUncompressed), actualUncompressed);
         }
 
         @Test
@@ -199,9 +202,21 @@ public class UtilsTest {
 
             assertEquals(expected, key);
         }
+
+        @Test
+        public void invalidPublicKey() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Invalid public key.");
+
+            String key = "0x1177e05dd93cdd6362f8648447f33d5676cbc5f42f4c4946ae1ad62bd4c0c4f357";
+            caver.utils.decompressPublicKey(key);
+        }
     }
 
     public static class compressedPublicKeyTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
         @Test
         public void compressedPublicKey() {
             String uncompressedKey = caver.wallet.keyring.generate().getPublicKey(false);
@@ -224,6 +239,14 @@ public class UtilsTest {
             String expected = caver.utils.compressPublicKey("019b186993b620455077b6bc37bf61666725d8d87ab33eb113ac0414cd48d78ff46e5ea48c6f22e8f19a77e5dbba9d209df60cbcb841b7e3e81fe444ba829831");
 
             assertEquals(expected, caver.utils.compressPublicKey(key));
+        }
+
+        @Test
+        public void invalidPublicKey() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Invalid public key.");
+
+            caver.utils.compressPublicKey("0x0977e05dd93cdd6362f8648447f33d5676cbc5f42f4c4946ae1ad62bd4c0c4f3570b1a104b67d1cd169bbf61dd557f15ab5ee8b661326096954caddadf34ae6ac8");
         }
     }
 


### PR DESCRIPTION
## Proposed changes

This PR added to logic that public key passed as parameter is valid in `compressPublicKey` and `decompressPublicKey`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
