### PR TITLE
enhanced the logic that check private key validation.

### DIFF
--- a/core/src/main/java/com/klaytn/caver/utils/Utils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/Utils.java
@@ -87,7 +87,7 @@ public class Utils {
         }
 
         ECPoint point = Sign.publicPointFromPrivate(Numeric.toBigInt(privateKey));
-        return point.isValid();
+        return !point.isInfinity() && point.isValid();
     }
 
     /**

--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -90,14 +90,16 @@ public class UtilsTest {
 
         @Test
         public void invalidPrivateKey() {
-            String[] invalidAddress = new String[] {
+            String[] invalidPrivateKey = new String[] {
                     "0xff6916ea19a50878e39c41cab1b41d0xff6916ea19a50878e39c41cab1bdd41dK",// Length is not 64
                     "0xff6916ea19a50878e39c41cab1b41d0xff6916ea19a50878e39c41cab1bdd4KK", // Not Hex String
-                    "d0xff69"
+                    "d0xff69",
+                    "0x0000000000000000000000000000000000000000000000000000000000000000", // Lower bound
+                    "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141" // Upper bound
             };
 
-            for(int i=0; i<invalidAddress.length; i++) {
-                assertFalse(caver.utils.isValidPrivateKey(invalidAddress[i]));
+            for(int i=0; i<invalidPrivateKey.length; i++) {
+                assertFalse(caver.utils.isValidPrivateKey(invalidPrivateKey[i]));
             }
         }
     }
@@ -106,7 +108,7 @@ public class UtilsTest {
         @Test
         public void validWalletKey() {
             String walletKey = caver.wallet.keyring.generate().getKlaytnWalletKey();
-            assertTrue(caver.utils.isKlaytnWalletKey(walletKey));
+            assertTrue(Utils.isKlaytnWalletKey(walletKey));
         }
 
         @Test
@@ -118,10 +120,11 @@ public class UtilsTest {
                     "0x63526af77dc34846a0909e5486f972c4a07074f0c94a2b9577675a6433098481" + "0x00" +"fc26de905386050894cddbb5a824318b96dde595", // invalid address - no prefix
                     "0x63526af77dc34846a0909e5486f972c4a07074f0c94a2b9575a6433098481" + "0x00" +"0xfc26de905386050894cddbb5a824318b96dde595", // invalid privateKey - invalid length
                     "63526af77dc34846a0909e5486f972c4a07074f0c94a2b9577675a6433098481" + "0x00" +"0xfc26de905386050894cddbb5a824318b96dde595", // invalid type - no prefix
+                    "0x00000000000000000000000000000000000000000000000000000000000000000x000xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
             };
 
             for(int i=0; i<invalidWalletKey.length; i++) {
-                assertFalse(caver.utils.isAddress(invalidWalletKey[i]));
+                assertFalse(Utils.isKlaytnWalletKey(invalidWalletKey[i]));
             }
         }
     }

--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -22,8 +22,8 @@ import static org.junit.Assert.*;
 
 @RunWith(Enclosed.class)
 public class UtilsTest {
-    static Caver caver = new Caver(Caver.DEFAULT_URL);
     public static class isAddressTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
         @Test
         public void lowerCaseAddressTest() {
             String[] lowercase = new String[] {
@@ -81,6 +81,8 @@ public class UtilsTest {
     }
 
     public static class isValidPrivateKeyTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void validPrivateKey() {
             String key = caver.wallet.keyring.generateSingleKey();
@@ -105,6 +107,8 @@ public class UtilsTest {
     }
 
     public static class isKlaytnWalletKeyTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void validWalletKey() {
             String walletKey = caver.wallet.keyring.generate().getKlaytnWalletKey();
@@ -119,17 +123,18 @@ public class UtilsTest {
                     "0x63526af77dc34846a0909e5486f972c4a07074f0c94a2b9577675a6433098481" + "0x00" +"0xfc26de905386050894cddbb5a824318b96dde59", // invalid address - invalid length
                     "0x63526af77dc34846a0909e5486f972c4a07074f0c94a2b9577675a6433098481" + "0x00" +"fc26de905386050894cddbb5a824318b96dde595", // invalid address - no prefix
                     "0x63526af77dc34846a0909e5486f972c4a07074f0c94a2b9575a6433098481" + "0x00" +"0xfc26de905386050894cddbb5a824318b96dde595", // invalid privateKey - invalid length
-                    "63526af77dc34846a0909e5486f972c4a07074f0c94a2b9577675a6433098481" + "0x00" +"0xfc26de905386050894cddbb5a824318b96dde595", // invalid type - no prefix
                     "0x00000000000000000000000000000000000000000000000000000000000000000x000xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
             };
 
             for(int i=0; i<invalidWalletKey.length; i++) {
-                assertFalse(Utils.isKlaytnWalletKey(invalidWalletKey[i]));
+                assertFalse(caver.utils.isKlaytnWalletKey(invalidWalletKey[i]));
             }
         }
     }
 
     public static class isValidPublicKeyTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void uncompressedKeyTest() {
             String key = caver.wallet.keyring.generate().getPublicKey();
@@ -179,6 +184,8 @@ public class UtilsTest {
     }
 
     public static class decompressPublicKeyTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void decompressPublicKey() {
             String compressed = "03434dedfc2eceed1e98fddfde3ebc57512c57f017195988cd5de62b722656b943";
@@ -205,6 +212,8 @@ public class UtilsTest {
     }
 
     public static class compressedPublicKeyTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void compressedPublicKey() {
             String uncompressedKey = caver.wallet.keyring.generate().getPublicKey(false);
@@ -231,6 +240,8 @@ public class UtilsTest {
     }
 
     public static class hashMessageTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void hashMessageTest() {
             String[] message = {"some data", "test data", "caver-java", "sign data", "0xaabbccdd", "0x11223344", "0x33445566"};
@@ -253,6 +264,8 @@ public class UtilsTest {
     }
 
     public static class parseKlaytnWalletKeyTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Rule
         public ExpectedException expectedException = ExpectedException.none();
 
@@ -296,6 +309,8 @@ public class UtilsTest {
     }
 
     public static class isHexTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void validHexTest() {
             String[] hex = new String[] {
@@ -320,6 +335,8 @@ public class UtilsTest {
     }
 
     public static class isHexStrictTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void validHexTest() {
             String[] hex = new String[] {
@@ -351,6 +368,8 @@ public class UtilsTest {
     }
 
     public static class addHexPrefixTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void addHexPrefixTest() {
             String hex = "1234";
@@ -368,6 +387,8 @@ public class UtilsTest {
     }
 
     public static class stripHexPrefixTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void stripHexPrefixTest() {
             String expected = "1234";
@@ -385,6 +406,8 @@ public class UtilsTest {
     }
 
     public static class convertToPebTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void from_peb() {
             String expected = "1";
@@ -675,6 +698,8 @@ public class UtilsTest {
     }
 
     public static class convertFromPebTest {
+
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
         @Test
         public void to_peb() {
             String amount = "1000000000000000000000000000";
@@ -965,6 +990,8 @@ public class UtilsTest {
     }
 
     public static class isNumberTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void validHexNumber() {
             String[] valid = new String[] {
@@ -993,6 +1020,8 @@ public class UtilsTest {
     }
 
     public static class isEmptySigTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void validEmptySig() {
             SignatureData emptySig = new SignatureData(
@@ -1043,6 +1072,8 @@ public class UtilsTest {
     }
 
     public static class generateRandomBytesTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void generateRandomBytes() {
             byte[] arr = caver.utils.generateRandomBytes(32);
@@ -1052,6 +1083,8 @@ public class UtilsTest {
     }
 
     public static class recoverTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         public void checkAddress(String expect, String actual) {
             expect = Numeric.prependHexPrefix(expect);
             actual = Numeric.prependHexPrefix(actual);
@@ -1084,6 +1117,7 @@ public class UtilsTest {
     }
 
     public static class decodeSignatureTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
 
         @Rule
         public ExpectedException expectedException = ExpectedException.none();
@@ -1118,6 +1152,8 @@ public class UtilsTest {
     }
 
     public static class recoverPublicKeyTest {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void recoverWithMessage() throws SignatureException {
             SingleKeyring keyring = caver.wallet.keyring.generate();
@@ -1157,6 +1193,8 @@ public class UtilsTest {
     }
 
     public static class publicKeyToAddress {
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
         @Test
         public void publicKeyToAddressWithDecompressedFormat() {
             String expected = "0x5b2840bcbc2be07fb12d9129ed3a02d8e4465944";

--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -112,7 +112,7 @@ public class UtilsTest {
         @Test
         public void validWalletKey() {
             String walletKey = caver.wallet.keyring.generate().getKlaytnWalletKey();
-            assertTrue(Utils.isKlaytnWalletKey(walletKey));
+            assertTrue(caver.utils.isKlaytnWalletKey(walletKey));
         }
 
         @Test
@@ -228,7 +228,7 @@ public class UtilsTest {
 
         @Rule
         public ExpectedException expectedException = ExpectedException.none();
-        
+
         @Test
         public void compressedPublicKey() {
             String uncompressedKey = caver.wallet.keyring.generate().getPublicKey(false);


### PR DESCRIPTION
## Proposed changes

This PR enhanced the logic that check private key validation.
  - In ECDSA256k1, The private key 'k' has a [1, n-1] which n has `FFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141`. 
 - So, The ECPoint instance generated from private key that has Lower bound (0x0) or upper bound(n) has X, Y point is null.
   - It can check a `ECPoint#isInfinity()`
 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
