### PR TITLE
modified the logic of caver.utils.compressedPublicKey()

### DIFF
--- a/core/src/main/java/com/klaytn/caver/utils/Utils.java
+++ b/core/src/main/java/com/klaytn/caver/utils/Utils.java
@@ -190,7 +190,7 @@ public class Utils {
         if(AccountKeyPublicUtils.isUncompressedPublicKey(publicKey)) {
             String noPrefixKey = stripHexPrefix(publicKey);
 
-            if(noPrefixKey.startsWith("04")) {
+            if(noPrefixKey.startsWith("04") && noPrefixKey.length() == 130) {
                 noPrefixKey = noPrefixKey.substring(2);
             }
 

--- a/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/utils/UtilsTest.java
@@ -276,6 +276,14 @@ public class UtilsTest {
 
             caver.utils.compressPublicKey("0x0977e05dd93cdd6362f8648447f33d5676cbc5f42f4c4946ae1ad62bd4c0c4f3570b1a104b67d1cd169bbf61dd557f15ab5ee8b661326096954caddadf34ae6ac8");
         }
+
+        @Test
+        public void compressedPublicKeyStartWith04Data() {
+            String key = "0x0497da4e69be4ff078c35c81b9007222f0e6382cf3eb15bd10ee39bf37a4948edffe50a29c49e90aa9b1e7e1b11c9b220fa1ab1bf3a3da27566d1fd13646fc62";
+            String compressed = caver.utils.compressPublicKey(key);
+
+            assertEquals(key, caver.utils.decompressPublicKey(compressed));
+        }
     }
 
     public static class hashMessageTest {


### PR DESCRIPTION
## Proposed changes

This PR modified caver.utils.compressedPublicKey as below. 
  - if the public key starts with 04, modify the condition to check whether this data is a tag or not.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
