### PR TITLE
Update CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,9 +195,6 @@ jobs:
           command: ./gradlew connectedDebugAndroidTest --debug --stacktrace
       - store_test_results:
           path: android_instrumented_test/build/outputs/androidTest-results/connected
-      - store_artifacts:
-          path: ~/circleci-caver-java-android/
-          destination: adb.log
 
   build_test_android:
     <<: *android_machine_ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaults: &defaults
 machine_ubuntu: &machine_ubuntu
   working_directory: ~/circleci-caver-java-major
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2004:202010-01
 
 android_machine_ubuntu: &android_machine_ubuntu
   working_directory: ~/circleci-caver-java-android


### PR DESCRIPTION
## Proposed changes

- Update machine image to Ubuntu 20.04 used at CircleCI pipelines
- Remove store_artifact step from unit_test_android

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Ubuntu 14.04, 16.04 will be deprecated May 31, 2022. https://circleci.com/blog/ubuntu-14-16-image-deprecation/

## Further comments

