### PR TITLE
Removed gas price from AbstractTransaction

### DIFF
--- a/core/ipfs.txt
+++ b/core/ipfs.txt
@@ -1,0 +1,1 @@
+This is IPFS test.

--- a/core/ipfs.txt
+++ b/core/ipfs.txt
@@ -1,1 +1,0 @@
-This is IPFS test.

--- a/core/src/main/java/com/klaytn/caver/methods/response/Transaction.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/Transaction.java
@@ -26,6 +26,7 @@ import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
 import com.klaytn.caver.transaction.type.*;
+import com.klaytn.caver.transaction.utils.AccessList;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.protocol.core.Response;
@@ -148,9 +149,19 @@ public class Transaction extends Response<Transaction.TransactionData> {
          */
         private String value;
 
+        /**
+         * Chain ID.
+         */
+        private String chainID;
+
+        /**
+         * An access list.
+         */
+        private AccessList accessList;
+
         public TransactionData() {}
 
-        public TransactionData(String blockHash, String blockNumber, String codeFormat, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio, String from, String gas, String gasPrice, String hash, boolean humanReadable, String key, String input, String nonce, String senderTxHash, List<SignatureData> signatures, String to, String transactionIndex, String type, String typeInt, String value) {
+        public TransactionData(String blockHash, String blockNumber, String codeFormat, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio, String from, String gas, String gasPrice, String hash, boolean humanReadable, String key, String input, String nonce, String senderTxHash, List<SignatureData> signatures, String to, String transactionIndex, String type, String typeInt, String value, String chainID, AccessList accesslist) {
             this.blockHash = blockHash;
             this.blockNumber = blockNumber;
             this.codeFormat = codeFormat;
@@ -172,6 +183,8 @@ public class Transaction extends Response<Transaction.TransactionData> {
             this.type = type;
             this.typeInt = typeInt;
             this.value = value;
+            this.chainID = chainID;
+            this.accessList = accesslist;
         }
 
         public String getBlockHash() {
@@ -344,6 +357,25 @@ public class Transaction extends Response<Transaction.TransactionData> {
             this.key = key;
         }
 
+        public String getChainID() {
+            if (chainID == null) {
+                return "";
+            }
+            return chainID;
+        }
+
+        public void setChainID(String chainID) {
+            this.chainID = chainID;
+        }
+
+        public AccessList getAccessList() {
+            return accessList;
+        }
+
+        public void setAccessList(AccessList accessList) {
+            this.accessList = accessList;
+        }
+
         /**
          * Convert TransactionData to Caver's transaction instance.
          * @param klay The Klay instance to fill gasPrice, chainId and nonce fields when signing a transaction.
@@ -352,49 +384,51 @@ public class Transaction extends Response<Transaction.TransactionData> {
         public AbstractTransaction convertToCaverTransaction(Klay klay) {
             switch (TransactionType.valueOf(this.getType())) {
                 case TxTypeLegacyTransaction:
-                    return LegacyTransaction.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getTo(), this.getInput(), this.getValue());
+                    return LegacyTransaction.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getTo(), this.getInput(), this.getValue());
                 case TxTypeValueTransfer:
-                    return ValueTransfer.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getTo(), this.getValue());
+                    return ValueTransfer.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getTo(), this.getValue());
                 case TxTypeFeeDelegatedValueTransfer:
-                    return FeeDelegatedValueTransfer.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue());
+                    return FeeDelegatedValueTransfer.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue());
                 case TxTypeFeeDelegatedValueTransferWithRatio:
-                    return FeeDelegatedValueTransferWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue());
+                    return FeeDelegatedValueTransferWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue());
                 case TxTypeValueTransferMemo:
-                    return ValueTransferMemo.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getTo(), this.getValue(), this.getInput());
+                    return ValueTransferMemo.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getTo(), this.getValue(), this.getInput());
                 case TxTypeFeeDelegatedValueTransferMemo:
-                    return FeeDelegatedValueTransferMemo.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue(), this.getInput());
+                    return FeeDelegatedValueTransferMemo.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue(), this.getInput());
                 case TxTypeFeeDelegatedValueTransferMemoWithRatio:
-                    return FeeDelegatedValueTransferMemoWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue(), this.getInput());
+                    return FeeDelegatedValueTransferMemoWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue(), this.getInput());
                 case TxTypeAccountUpdate:
-                    return AccountUpdate.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), Account.createFromRLPEncoding(this.getFrom(), this.getKey()));
+                    return AccountUpdate.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), Account.createFromRLPEncoding(this.getFrom(), this.getKey()));
                 case TxTypeFeeDelegatedAccountUpdate:
-                    return FeeDelegatedAccountUpdate.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), Account.createFromRLPEncoding(this.getFrom(), this.getKey()));
+                    return FeeDelegatedAccountUpdate.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), Account.createFromRLPEncoding(this.getFrom(), this.getKey()));
                 case TxTypeFeeDelegatedAccountUpdateWithRatio:
-                    return FeeDelegatedAccountUpdateWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), Account.createFromRLPEncoding(this.getFrom(), this.getKey()));
+                    return FeeDelegatedAccountUpdateWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), Account.createFromRLPEncoding(this.getFrom(), this.getKey()));
                 case TxTypeSmartContractDeploy:
-                    return SmartContractDeploy.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getTo(), this.getValue(), this.getInput(), false, Numeric.toHexStringWithPrefix(CodeFormat.EVM));
+                    return SmartContractDeploy.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getTo(), this.getValue(), this.getInput(), false, Numeric.toHexStringWithPrefix(CodeFormat.EVM));
                 case TxTypeFeeDelegatedSmartContractDeploy:
-                    return FeeDelegatedSmartContractDeploy.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue(), this.getInput(), false, Numeric.toHexStringWithPrefix(CodeFormat.EVM));
+                    return FeeDelegatedSmartContractDeploy.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue(), this.getInput(), false, Numeric.toHexStringWithPrefix(CodeFormat.EVM));
                 case TxTypeFeeDelegatedSmartContractDeployWithRatio:
-                    return FeeDelegatedSmartContractDeployWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue(), this.getInput(), false, Numeric.toHexStringWithPrefix(CodeFormat.EVM));
+                    return FeeDelegatedSmartContractDeployWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue(), this.getInput(), false, Numeric.toHexStringWithPrefix(CodeFormat.EVM));
                 case TxTypeSmartContractExecution:
-                    return SmartContractExecution.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getTo(), this.getValue(), this.getInput());
+                    return SmartContractExecution.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getTo(), this.getValue(), this.getInput());
                 case TxTypeFeeDelegatedSmartContractExecution:
-                    return FeeDelegatedSmartContractExecution.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue(), this.getInput());
+                    return FeeDelegatedSmartContractExecution.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getTo(), this.getValue(), this.getInput());
                 case TxTypeFeeDelegatedSmartContractExecutionWithRatio:
-                    return FeeDelegatedSmartContractExecutionWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue(), this.getInput());
+                    return FeeDelegatedSmartContractExecutionWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getTo(), this.getValue(), this.getInput());
                 case TxTypeCancel:
-                    return Cancel.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures());
+                    return Cancel.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures());
                 case TxTypeFeeDelegatedCancel:
-                    return FeeDelegatedCancel.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures());
+                    return FeeDelegatedCancel.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures());
                 case TxTypeFeeDelegatedCancelWithRatio:
-                    return FeeDelegatedCancelWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio());
+                    return FeeDelegatedCancelWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio());
                 case TxTypeChainDataAnchoring:
-                    return ChainDataAnchoring.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getInput());
+                    return ChainDataAnchoring.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getInput());
                 case TxTypeFeeDelegatedChainDataAnchoring:
-                    return FeeDelegatedChainDataAnchoring.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getInput());
+                    return FeeDelegatedChainDataAnchoring.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getInput());
                 case TxTypeFeeDelegatedChainDataAnchoringWithRatio:
-                    return FeeDelegatedChainDataAnchoringWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), "", this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getInput());
+                    return FeeDelegatedChainDataAnchoringWithRatio.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getFeePayer(), this.getFeePayerSignatures(), this.getFeeRatio(), this.getInput());
+                case TxTypeEthereumAccessList:
+                    return EthereumAccessList.create(klay, this.getFrom(), this.getNonce(), this.getGas(), this.getGasPrice(), this.getChainID(), this.getSignatures(), this.getTo(), this.getInput(), this.getValue(), this.getAccessList());
                 default:
                     throw new RuntimeException("Invalid transaction type : Cannot create a transaction instance that has Tx type :" + this.getType());
             }

--- a/core/src/main/java/com/klaytn/caver/methods/response/TransactionReceipt.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/TransactionReceipt.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.klaytn.caver.crypto.KlaySignatureData;
+import com.klaytn.caver.transaction.utils.AccessList;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.protocol.core.Response;
 import org.web3j.utils.Numeric;
@@ -219,10 +220,20 @@ public class TransactionReceipt extends Response<TransactionReceipt.TransactionR
          */
         private String value;
 
+        /**
+         * Chain ID.
+         */
+        private String chainID;
+
+        /**
+         * An access list.
+         */
+        private AccessList accessList;
+
         public TransactionReceiptData() {
         }
 
-        public TransactionReceiptData(String blockHash, String blockNumber, String codeFormat, String contractAddress, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio, String from, String gas, String gasPrice, String gasUsed, boolean humanReadable, String key, String input, List<KlayLogs.Log> logs, String logsBloom, String nonce, String senderTxHash, List<SignatureData> signatures, String status, String to, String transactionIndex, String transactionHash, String txError, String type, String typeInt, String value) {
+        public TransactionReceiptData(String blockHash, String blockNumber, String codeFormat, String contractAddress, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio, String from, String gas, String gasPrice, String gasUsed, boolean humanReadable, String key, String input, List<KlayLogs.Log> logs, String logsBloom, String nonce, String senderTxHash, List<SignatureData> signatures, String status, String to, String transactionIndex, String transactionHash, String txError, String type, String typeInt, String value, String chainID, AccessList accessList) {
             this.blockHash = blockHash;
             this.blockNumber = blockNumber;
             this.codeFormat = codeFormat;
@@ -250,6 +261,8 @@ public class TransactionReceipt extends Response<TransactionReceipt.TransactionR
             this.type = type;
             this.typeInt = typeInt;
             this.value = value;
+            this.chainID = chainID;
+            this.accessList = accessList;
         }
 
         public String getBlockHash() {
@@ -468,6 +481,22 @@ public class TransactionReceipt extends Response<TransactionReceipt.TransactionR
 
         public void setValue(String value) {
             this.value = value;
+        }
+
+        public String getChainID() {
+            return chainID;
+        }
+
+        public void setChainID(String chainID) {
+            this.chainID = chainID;
+        }
+
+        public AccessList getAccessList() {
+            return accessList;
+        }
+
+        public void setAccessList(AccessList accessList) {
+            this.accessList = accessList;
         }
     }
 

--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractFeeDelegatedWithRatioTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractFeeDelegatedWithRatioTransaction.java
@@ -74,15 +74,14 @@ abstract public class AbstractFeeDelegatedWithRatioTransaction extends AbstractF
      * @param from The address of the sender.
      * @param nonce A value used to uniquely identify a sender’s transaction.
      * @param gas The maximum amount of gas the transaction is allowed to use.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
      * @param chainId Network ID
      * @param signatures A signature list
      * @param feePayer The address of the fee payer.
      * @param feePayerSignatures The fee payers's signatures.
      * @param feeRatio A fee ratio of the fee payer.
      */
-    public AbstractFeeDelegatedWithRatioTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio) {
-        super(klaytnCall, type, from, nonce, gas, gasPrice, chainId, signatures, feePayer, feePayerSignatures);
+    public AbstractFeeDelegatedWithRatioTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String chainId, List<SignatureData> signatures, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio) {
+        super(klaytnCall, type, from, nonce, gas, chainId, signatures, feePayer, feePayerSignatures);
         setFeeRatio(feeRatio);
     }
 

--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
@@ -72,11 +72,6 @@ abstract public class AbstractTransaction {
     private String gas;
 
     /**
-     * A unit price of gas in peb the sender will pay for a transaction fee.
-     */
-    private String gasPrice = "0x";
-
-    /**
      * Network ID
      */
     private String chainId = "0x";
@@ -96,7 +91,6 @@ abstract public class AbstractTransaction {
 
         private String from;
         private String nonce = "0x";
-        private String gasPrice = "0x";
         private String chainId = "0x";
         private Klay klaytnCall = null;
         private List<SignatureData> signatures = new ArrayList<>();
@@ -127,16 +121,6 @@ abstract public class AbstractTransaction {
 
         public B setGas(BigInteger gas) {
             setGas(Numeric.toHexStringWithPrefix(gas));
-            return (B) this;
-        }
-
-        public B setGasPrice(String gasPrice) {
-            this.gasPrice = gasPrice;
-            return (B) this;
-        }
-
-        public B setGasPrice(BigInteger gasPrice) {
-            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return (B) this;
         }
 
@@ -180,7 +164,6 @@ abstract public class AbstractTransaction {
                 builder.from,
                 builder.nonce,
                 builder.gas,
-                builder.gasPrice,
                 builder.chainId,
                 builder.signatures
         );
@@ -193,16 +176,14 @@ abstract public class AbstractTransaction {
      * @param from The address of the sender.
      * @param nonce A value used to uniquely identify a sender’s transaction.
      * @param gas The maximum amount of gas the transaction is allowed to use.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
      * @param chainId Network ID
      * @param signatures A Signature list
      */
-    public AbstractTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures) {
+    public AbstractTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String chainId, List<SignatureData> signatures) {
         setKlaytnCall(klaytnCall);
         setType(type);
         setFrom(from);
         setNonce(nonce);
-        setGasPrice(gasPrice);
         setGas(gas);
         setChainId(chainId);
         setSignatures(signatures);
@@ -360,33 +341,8 @@ abstract public class AbstractTransaction {
      * @param rlpEncoded A List of RLP-encoded transaction strings.
      * @return String
      */
-    public String combineSignedRawTransactions(List<String> rlpEncoded) {
-        boolean fillVariable = false;
+    public abstract String combineSignedRawTransactions(List<String> rlpEncoded);
 
-        // If the signatures are empty, there may be an undefined member variable.
-        // In this case, the empty information is filled with the decoded result.
-        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
-
-        for(String encodedStr : rlpEncoded) {
-            AbstractTransaction txObj = TransactionDecoder.decode(encodedStr);
-
-            if(fillVariable) {
-                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
-                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
-                fillVariable = false;
-            }
-
-            // Signatures can only be combined for the same transaction.
-            // Therefore, compare whether the decoded transaction is the same as this.
-            if(!this.compareTxField(txObj, false)) {
-                throw new RuntimeException("Transactions containing different information cannot be combined.");
-            }
-
-            this.appendSignatures(txObj.getSignatures());
-        }
-
-        return this.getRLPEncoding();
-    }
 
     /**
      * Returns a RawTransaction(RLP-encoded transaction string)
@@ -445,15 +401,10 @@ abstract public class AbstractTransaction {
             if(this.chainId.equals("0x")) {
                 this.chainId = klaytnCall.getChainID().send().getResult();
             }
-
-            if(this.gasPrice.equals("0x")) {
-                this.gasPrice = klaytnCall.getGasPrice().send().getResult();
-            }
-
         }
 
-        if(this.nonce.equals("0x") || this.chainId.equals("0x") || this.gasPrice.equals("0x")) {
-            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId, gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        if(this.nonce.equals("0x") || this.chainId.equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
         }
     }
 
@@ -468,7 +419,6 @@ abstract public class AbstractTransaction {
         if(!this.getFrom().toLowerCase().equals(txObj.getFrom().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getNonce()).equals(Numeric.toBigInt(txObj.getNonce()))) return false;
         if(!Numeric.toBigInt(this.getGas()).equals(Numeric.toBigInt(txObj.getGas()))) return false;
-        if(!Numeric.toBigInt(this.getGasPrice()).equals(Numeric.toBigInt(txObj.getGasPrice()))) return false;
 
         if(checkSig) {
             List<SignatureData> dataList = this.getSignatures();
@@ -491,10 +441,6 @@ abstract public class AbstractTransaction {
     public void validateOptionalValues(boolean checkChainID) {
         if(this.getNonce() == null || this.getNonce().isEmpty() || this.getNonce().equals("0x")) {
             throw new RuntimeException("nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.");
-        }
-
-        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
-            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
         }
 
         if(checkChainID) {
@@ -613,14 +559,6 @@ abstract public class AbstractTransaction {
     }
 
     /**
-     * Getter function for gas price
-     * @return String
-     */
-    public String getGasPrice() {
-        return gasPrice;
-    }
-
-    /**
      * Getter function for chain id
      * @return String
      */
@@ -708,30 +646,6 @@ abstract public class AbstractTransaction {
      */
     public void setNonce(BigInteger nonce) {
         setNonce(Numeric.toHexStringWithPrefix(nonce));
-    }
-
-    /**
-     * Setter function for gas price.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
-     */
-    public void setGasPrice(String gasPrice) {
-        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
-            gasPrice = "0x";
-        }
-
-        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
-            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
-        }
-
-        this.gasPrice = gasPrice;
-    }
-
-    /**
-     * Setter function for gas price.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
-     */
-    public void setGasPrice(BigInteger gasPrice) {
-        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.AccountKeyRoleBased;
-import com.klaytn.caver.transaction.type.LegacyTransaction;
 import com.klaytn.caver.transaction.type.TransactionType;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.AbstractKeyring;
@@ -268,8 +267,8 @@ abstract public class AbstractTransaction {
      * @throws IOException
      */
     public AbstractTransaction sign(AbstractKeyring keyring, Function<AbstractTransaction, String> signer) throws IOException  {
-        if(this.getType().equals(TransactionType.TxTypeLegacyTransaction.toString()) && keyring.isDecoupled()) {
-            throw new IllegalArgumentException("A legacy transaction cannot be signed with a decoupled keyring.");
+        if(TransactionHelper.isEthereumTransaction(this.getType()) && keyring.isDecoupled()) {
+            throw new IllegalArgumentException(this.getType() + " cannot be signed with a decoupled keyring.");
         }
 
         if(this.from.equals("0x") || this.from.equals(Utils.DEFAULT_ZERO_ADDRESS)){
@@ -312,8 +311,8 @@ abstract public class AbstractTransaction {
      * @throws IOException
      */
     public AbstractTransaction sign(AbstractKeyring keyring, int index, Function<AbstractTransaction, String> signer) throws IOException {
-        if(this.getType().equals(TransactionType.TxTypeLegacyTransaction.toString()) && keyring.isDecoupled()) {
-            throw new IllegalArgumentException("A legacy transaction cannot be signed with a decoupled keyring.");
+        if(TransactionHelper.isEthereumTransaction(this.getType()) && keyring.isDecoupled()) {
+            throw new IllegalArgumentException(this.getType() + " cannot be signed with a decoupled keyring.");
         }
 
         if(this.from.equals("0x") || this.from.equals(Utils.DEFAULT_ZERO_ADDRESS)){
@@ -514,12 +513,12 @@ abstract public class AbstractTransaction {
      * @return List&lt;String&gt;
      */
     public List<SignatureData> refineSignature(List<SignatureData> signatureDataList) {
-        boolean isLegacy = this.getType().equals(TransactionType.TxTypeLegacyTransaction.toString());
+        boolean isEthereumTransaction = TransactionHelper.isEthereumTransaction(this.getType());
 
         List<SignatureData> refinedList = SignatureData.refineSignature(signatureDataList);
 
-        if(isLegacy && refinedList.size() > 1) {
-            throw new RuntimeException("LegacyTransaction cannot have multiple signature.");
+        if(isEthereumTransaction && refinedList.size() > 1) {
+            throw new RuntimeException(this.getType() + " cannot have multiple signature.");
         }
 
         return refinedList;
@@ -647,8 +646,8 @@ abstract public class AbstractTransaction {
     }
 
     public void setFrom(String from) {
-        //"From" field in LegacyTransaction allows null
-        if(this instanceof LegacyTransaction) {
+        //"From" field in EthereumTransaction allows null
+        if(TransactionHelper.isEthereumTransaction(this.getType())) {
             if(from == null || from.isEmpty() || from.equals("0x") || from.equals(Utils.DEFAULT_ZERO_ADDRESS)) from = Utils.DEFAULT_ZERO_ADDRESS;
         } else {
             if(from == null) {

--- a/core/src/main/java/com/klaytn/caver/transaction/TransactionDecoder.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/TransactionDecoder.java
@@ -70,6 +70,8 @@ public class TransactionDecoder {
             return FeeDelegatedValueTransferMemoWithRatio.decode(rlpBytes);
         } else if(rlpBytes[0] == TransactionType.TxTypeFeeDelegatedSmartContractDeployWithRatio.getType()) {
             return FeeDelegatedSmartContractDeployWithRatio.decode(rlpBytes);
+        } else if ((rlpBytes[0] << 8 | rlpBytes[1]) == TransactionType.TxTypeEthereumAccessList.getType()) {
+            return EthereumAccessList.decode(rlpBytes);
         }
         else {
             return LegacyTransaction.decode(rlpBytes);

--- a/core/src/main/java/com/klaytn/caver/transaction/TransactionHelper.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/TransactionHelper.java
@@ -18,9 +18,13 @@ package com.klaytn.caver.transaction;
 
 import com.klaytn.caver.methods.response.Transaction;
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.type.TransactionType;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
+
+import static com.klaytn.caver.transaction.type.TransactionType.TxTypeEthereumAccessList;
 
 /**
  * This class is a helper class provides methods that handles Transaction object comfortably.
@@ -84,4 +88,33 @@ public class TransactionHelper {
         AbstractFeeDelegatedTransaction tx = (AbstractFeeDelegatedTransaction)TransactionDecoder.decode(rawTx);
         return tx.recoverFeePayerPublicKeys();
     }
+
+    /**
+     * Returns true if the tx type is EthereumTransaction.
+     *
+     * @param type Transaction type integer.
+     * @return
+     */
+    public static boolean isEthereumTransaction(int type) {
+        if (type == TransactionType.TxTypeLegacyTransaction.getType() || type == TxTypeEthereumAccessList.getType()) {
+            return true;
+        }
+        return false;
+    }
+    /**
+     * Returns true if the tx type is EthereumTransaction.
+     *
+     * @param type Transaction type string.
+     * @return
+     */
+    public static boolean isEthereumTransaction(String type) {
+        if (
+                Objects.equals(type, TransactionType.TxTypeLegacyTransaction.toString()) ||
+                        Objects.equals(type, TransactionType.TxTypeEthereumAccessList.toString())
+        ) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/TxPropertyBuilder.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/TxPropertyBuilder.java
@@ -31,6 +31,14 @@ public class TxPropertyBuilder {
     }
 
     /**
+     * Creates a Builder of EthereumAccessList
+     * @return EthereumAccessList.Builder
+     */
+    public static EthereumAccessList.Builder ethereumAccessList() {
+        return new EthereumAccessList.Builder();
+    }
+
+    /**
      * Creates a Builder of ValueTransfer
      * @return ValueTransfer.Builder
      */

--- a/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
@@ -19,11 +19,14 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,10 +44,16 @@ public class AccountUpdate extends AbstractTransaction {
     Account account;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * AccountUpdate Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<AccountUpdate.Builder> {
         Account account;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeAccountUpdate.toString());
@@ -52,6 +61,16 @@ public class AccountUpdate extends AbstractTransaction {
 
         public Builder setAccount(Account account) {
             this.account = account;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -92,6 +111,7 @@ public class AccountUpdate extends AbstractTransaction {
     public AccountUpdate(AccountUpdate.Builder builder) {
         super(builder);
         setAccount(builder.account);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -112,11 +132,43 @@ public class AccountUpdate extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setAccount(account);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -241,8 +293,76 @@ public class AccountUpdate extends AbstractTransaction {
         if(!this.getAccount().getRLPEncodingAccountKey().equals(txObj.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            AccountUpdate txObj = (AccountUpdate) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
@@ -316,7 +316,7 @@ public class AccountUpdate extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             AccountUpdate txObj = (AccountUpdate) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
@@ -18,11 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,13 +36,29 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/basic#txtypecancel to see more detail.
  */
 public class Cancel extends AbstractTransaction {
+    /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
 
     /**
      * Cancel Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<Cancel.Builder> {
+        String gasPrice = "0x";
+
         public Builder() {
             super(TransactionType.TxTypeCancel.toString());
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+            return this;
         }
 
         public Cancel build() {
@@ -77,6 +96,7 @@ public class Cancel extends AbstractTransaction {
      */
     public Cancel(Cancel.Builder builder) {
         super(builder);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -90,8 +110,50 @@ public class Cancel extends AbstractTransaction {
      * @param signatures A Signature list
      */
     public Cancel(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures) {
-        super(klaytnCall, TransactionType.TxTypeCancel.toString(), from, nonce, gas, gasPrice, chainId, signatures);
+        super(
+                klaytnCall,
+                TransactionType.TxTypeCancel.toString(),
+                from,
+                nonce,
+                gas,
+                chainId,
+                signatures
+        );
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded Cancel string.
@@ -202,7 +264,76 @@ public class Cancel extends AbstractTransaction {
     public boolean compareTxField(AbstractTransaction obj, boolean checkSig) {
         if(!super.compareTxField(obj, checkSig)) return false;
         if(!(obj instanceof Cancel)) return false;
+        Cancel txObj = (Cancel) obj;
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            Cancel txObj = (Cancel) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
@@ -288,7 +288,7 @@ public class Cancel extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             Cancel txObj = (Cancel) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
@@ -310,7 +310,7 @@ public class ChainDataAnchoring extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             ChainDataAnchoring txObj = (ChainDataAnchoring) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
@@ -18,12 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,10 +42,16 @@ public class ChainDataAnchoring extends AbstractTransaction {
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * ChainDataAnchoring Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<ChainDataAnchoring.Builder> {
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeChainDataAnchoring.toString());
@@ -51,6 +59,16 @@ public class ChainDataAnchoring extends AbstractTransaction {
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -91,6 +109,7 @@ public class ChainDataAnchoring extends AbstractTransaction {
     public ChainDataAnchoring(ChainDataAnchoring.Builder builder) {
         super(builder);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -105,9 +124,51 @@ public class ChainDataAnchoring extends AbstractTransaction {
      * @param input Data of the service chain.
      */
     public ChainDataAnchoring(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String input) {
-        super(klaytnCall, TransactionType.TxTypeChainDataAnchoring.toString(), from, nonce, gas, gasPrice, chainId, signatures);
+        super(
+                klaytnCall,
+                TransactionType.TxTypeChainDataAnchoring.toString(),
+                from,
+                nonce,
+                gas,
+                chainId,
+                signatures
+        );
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded ChainDataAnchoring string.
@@ -226,9 +287,78 @@ public class ChainDataAnchoring extends AbstractTransaction {
         ChainDataAnchoring txObj = (ChainDataAnchoring)obj;
 
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            ChainDataAnchoring txObj = (ChainDataAnchoring) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for input

--- a/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
@@ -1,0 +1,608 @@
+/*
+ * Copyright 2022 The caver-java Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.klaytn.caver.transaction.type;
+
+import com.klaytn.caver.account.AccountKeyRoleBased;
+import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionHasher;
+import com.klaytn.caver.transaction.TransactionHelper;
+import com.klaytn.caver.transaction.utils.AccessList;
+import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
+import com.klaytn.caver.wallet.keyring.AbstractKeyring;
+import com.klaytn.caver.wallet.keyring.KeyringFactory;
+import com.klaytn.caver.wallet.keyring.SignatureData;
+import org.web3j.crypto.Hash;
+import org.web3j.rlp.*;
+import org.web3j.utils.Numeric;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Represents an ethereum access list transaction.
+ */
+public class EthereumAccessList extends AbstractTransaction {
+    /**
+     * The account address that will receive the transferred value.
+     */
+    String to = "0x";
+
+    /**
+     * Data attached to the transaction, used for transaction execution.
+     */
+    String input = "0x";
+
+    /**
+     * The amount of KLAY in peb to be transferred.
+     */
+    String value = "0x00";
+
+    /**
+     * Access list is an EIP-2930 access list.
+     */
+    AccessList accessList;
+
+    /**
+     * EthereumAccessList Builder class
+     */
+    public static class Builder extends AbstractTransaction.Builder<EthereumAccessList.Builder> {
+        private String to = "0x";
+        private String value = "0x0";
+        private String input = "0x";
+        private AccessList accessList = new AccessList();
+
+        public Builder() {
+            super(TransactionType.TxTypeEthereumAccessList.toString());
+        }
+
+        public Builder setValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder setValue(BigInteger value) {
+            setValue(Numeric.toHexStringWithPrefix(value));
+            return this;
+        }
+
+        public Builder setInput(String input) {
+            this.input = input;
+            return this;
+        }
+
+        public Builder setTo(String to) {
+            this.to = to;
+            return this;
+        }
+
+        public Builder setAccessList(AccessList accessList) {
+            this.accessList = accessList;
+            return this;
+        }
+
+        public EthereumAccessList build() {
+            return new EthereumAccessList(this);
+        }
+    }
+
+    /**
+     * Creates a EthereumAccessList instance.
+     *
+     * @param builder EthereumAccessList.Builder instance.
+     * @return EthereumAccessList
+     */
+    public static EthereumAccessList create(EthereumAccessList.Builder builder) {
+        return new EthereumAccessList(builder);
+    }
+
+
+    /**
+     * Create a EthereumAccessList instance.
+     *
+     * @param klaytnCall Klay RPC instance
+     * @param from       The address of the sender.
+     * @param nonce      A value used to uniquely identify a sender’s transaction.
+     * @param gas        The maximum amount of gas the transaction is allowed to use.
+     * @param gasPrice   A unit price of gas in peb the sender will pay for a transaction fee.
+     * @param chainId    Network ID
+     * @param signatures A Signature list
+     * @param to         The account address that will receive the transferred value.
+     * @param input      Data attached to the transaction, used for transaction execution.
+     * @param value      The amount of KLAY in peb to be transferred.
+     * @param accessList The EIP-2930 access list.
+     * @return EthereumAccessList
+     */
+    public static EthereumAccessList create(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String to, String input, String value, AccessList accessList) {
+        return new EthereumAccessList(klaytnCall, from, nonce, gas, gasPrice, chainId, signatures, to, input, value, accessList);
+    }
+
+    /**
+     * Creates a EthereumAccessList instance.
+     *
+     * @param builder EthereumAccessList.Builder instance.
+     */
+    public EthereumAccessList(EthereumAccessList.Builder builder) {
+        super(builder);
+
+        setTo(builder.to);
+        setValue(builder.value);
+        setInput(builder.input);
+        setAccessList(builder.accessList);
+    }
+
+
+    /**
+     * Create a EthereumAccessList instance.
+     *
+     * @param klaytnCall Klay RPC instance
+     * @param from       The address of the sender.
+     * @param nonce      A value used to uniquely identify a sender’s transaction.
+     * @param gas        The maximum amount of gas the transaction is allowed to use.
+     * @param gasPrice   A unit price of gas in peb the sender will pay for a transaction fee.
+     * @param chainId    Network ID
+     * @param signatures A Signature list
+     * @param to         The account address that will receive the transferred value.
+     * @param input      Data attached to the transaction, used for transaction execution.
+     * @param value      The amount of KLAY in peb to be transferred.
+     */
+    public EthereumAccessList(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String to, String input, String value, AccessList accessList) {
+        super(
+                klaytnCall,
+                TransactionType.TxTypeEthereumAccessList.toString(),
+                from,
+                nonce,
+                gas,
+                gasPrice,
+                chainId,
+                signatures
+        );
+        setTo(to);
+        setValue(value);
+        setInput(input);
+        setAccessList(accessList);
+    }
+
+    @Override
+    public String getRLPEncoding() {
+        // TransactionPayload = 0x7801 + encode([chainId, nonce, gasPrice, gas, to, value, data, accessList, signatureYParity, signatureR, signatureS])
+        this.validateOptionalValues(true);
+
+        List<RlpType> rlpTypeList = new ArrayList<>();
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getChainId())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getNonce())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getGasPrice())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getGas())));
+        rlpTypeList.add(RlpString.create(Numeric.hexStringToByteArray(this.getTo())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getValue())));
+        rlpTypeList.add(RlpString.create(Numeric.hexStringToByteArray(this.getInput())));
+        rlpTypeList.add(this.getAccessList().toRlpList());
+        SignatureData signatureData = this.getSignatures().get(0);
+        rlpTypeList.addAll(signatureData.toRlpList().getValues());
+
+        byte[] encodedTransaction = RlpEncoder.encode(new RlpList(rlpTypeList));
+        byte[] type = Numeric.toBytesPadded(BigInteger.valueOf(TransactionType.TxTypeEthereumAccessList.getType()), 2);
+        byte[] rawTx = BytesUtils.concat(type, encodedTransaction);
+
+        return Numeric.toHexString(rawTx);
+    }
+
+    @Override
+    public String getCommonRLPEncodingForSignature() {
+        return getRLPEncodingForSignature();
+    }
+
+    /**
+     * Returns the RLP-encoded string to make the signature of this transaction.
+     *
+     * @return String
+     */
+    @Override
+    public String getRLPEncodingForSignature() {
+        // SigRLP = 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
+
+        this.validateOptionalValues(true);
+
+        List<RlpType> rlpTypeList = new ArrayList<>();
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getChainId())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getNonce())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getGasPrice())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getGas())));
+        rlpTypeList.add(RlpString.create(Numeric.hexStringToByteArray(this.getTo())));
+        rlpTypeList.add(RlpString.create(Numeric.toBigInt(this.getValue())));
+        rlpTypeList.add(RlpString.create(Numeric.hexStringToByteArray(this.getInput())));
+        rlpTypeList.add(this.getAccessList().toRlpList());
+
+        byte[] encodedTransaction = RlpEncoder.encode(new RlpList(rlpTypeList));
+        byte[] type = new byte[]{(byte) TransactionType.TxTypeEthereumAccessList.getType()};
+        byte[] rawTx = BytesUtils.concat(type, encodedTransaction);
+
+        return Numeric.toHexString(rawTx);
+    }
+
+    /**
+     * Check equals txObj passed parameter and Current instance.
+     *
+     * @param obj      The AbstractTransaction Object to compare
+     * @param checkSig Check whether signatures field is equal.
+     * @return boolean
+     */
+    @Override
+    public boolean compareTxField(AbstractTransaction obj, boolean checkSig) {
+        if (!super.compareTxField(obj, checkSig)) return false;
+        if (!(obj instanceof EthereumAccessList)) return false;
+        EthereumAccessList txObj = (EthereumAccessList) obj;
+
+        if (!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
+        if (!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
+        if (!this.getInput().equals(txObj.getInput())) return false;
+        if (!this.getAccessList().equals(txObj.getAccessList())) return false;
+
+        return true;
+    }
+
+
+    /**
+     * Decodes a RLP-encoded EthereumAccessList string.
+     *
+     * @param rlpEncoded RLP-encoded EthereumAccessList string
+     * @return EthereumAccessList
+     */
+    public static EthereumAccessList decode(String rlpEncoded) {
+        return decode(Numeric.hexStringToByteArray(rlpEncoded));
+    }
+
+    /**
+     * Decodes a RLP-encoded EthereumAccessList byte array.
+     *
+     * @param rlpEncoded RLP-encoded EthereumAccessList byte array.
+     * @return EthereumAccessList
+     */
+    public static EthereumAccessList decode(byte[] rlpEncoded) {
+        // TxHashRLP = 0x7801 + encode([chainId, nonce, gasPrice, gas, to, value, data, accessList, signatureYParity, signatureR, signatureS])
+        try {
+            if ((rlpEncoded[0] << 8 | rlpEncoded[1]) != TransactionType.TxTypeEthereumAccessList.getType()) {
+                throw new IllegalArgumentException("Invalid RLP-encoded tag - " + TransactionType.TxTypeEthereumAccessList.toString());
+            }
+            byte[] detachedType = Arrays.copyOfRange(rlpEncoded, 2, rlpEncoded.length);
+            RlpList rlpList = RlpDecoder.decode(detachedType);
+            List<RlpType> values = ((RlpList) rlpList.getValues().get(0)).getValues();
+
+            BigInteger chainId = ((RlpString) values.get(0)).asPositiveBigInteger();
+            BigInteger nonce = ((RlpString) values.get(1)).asPositiveBigInteger();
+            BigInteger gasPrice = ((RlpString) values.get(2)).asPositiveBigInteger();
+            BigInteger gas = ((RlpString) values.get(3)).asPositiveBigInteger();
+            String to = ((RlpString) values.get(4)).asString();
+            BigInteger value = ((RlpString) values.get(5)).asPositiveBigInteger();
+            String input = ((RlpString) values.get(6)).asString();
+
+            AccessList accessList = AccessList.decode((RlpList) values.get(7));
+
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setFrom(null)
+                    .setInput(input)
+                    .setValue(value)
+                    .setChainId(chainId)
+                    .setNonce(nonce)
+                    .setGas(gas)
+                    .setGasPrice(gasPrice)
+                    .setNonce(nonce)
+                    .setTo(to)
+                    .setAccessList(accessList)
+                    .build();
+
+            byte[] v = ((RlpString) values.get(8)).getBytes();
+            byte[] r = ((RlpString) values.get(9)).getBytes();
+            byte[] s = ((RlpString) values.get(10)).getBytes();
+            SignatureData signatureData = new SignatureData(v, r, s);
+
+            ethereumAccessList.appendSignatures(signatureData);
+            return ethereumAccessList;
+        } catch (Exception e) {
+            throw new RuntimeException("There is an error while decoding process.");
+        }
+    }
+
+    /**
+     * Appends signatures array to transaction.
+     * EthereumAccessList transaction cannot have more than one signature, so an error occurs if the transaction already has a signature.
+     * @param signatureData SignatureData instance contains ECDSA signature data
+     */
+    @Override
+    public void appendSignatures(SignatureData signatureData) {
+        if(this.getSignatures().size() != 0 && !Utils.isEmptySig(this.getSignatures().get(0))) {
+            throw new RuntimeException("Signatures already defined." + TransactionType.TxTypeEthereumAccessList.toString() + " cannot include more than one signature.");
+        }
+
+        if (!Utils.isEmptySig(signatureData)) {
+            int v = Integer.decode(signatureData.getV());
+            if (v != 0 && v != 1) {
+                throw new RuntimeException("Invalid signature: The y-parity of the transaction should either be 0 or 1.");
+            }
+        };
+        super.appendSignatures(signatureData);
+    }
+
+    /**
+     * Appends signatures array to transaction.
+     * EthereumAccessList transaction cannot have more than one signature, so an error occurs if the transaction already has a signature.
+     * @param signatureData List of SignatureData contains ECDSA signature data
+     */
+    @Override
+    public void appendSignatures(List<SignatureData> signatureData) {
+        if(this.getSignatures().size() != 0 && !Utils.isEmptySig(this.getSignatures())) {
+            throw new RuntimeException("Signatures already defined." + TransactionType.TxTypeEthereumAccessList.toString() + " cannot include more than one signature.");
+        }
+
+        if(signatureData.size() != 1) {
+            throw new RuntimeException("Signatures are too long " + TransactionType.TxTypeEthereumAccessList.toString() + " cannot include more than one signature.");
+        }
+
+        SignatureData signature = signatureData.get(0);
+        if (!Utils.isEmptySig(signature)) {
+            int v = Integer.decode(signature.getV());
+            if (v != 0 && v != 1) {
+                throw new RuntimeException("Invalid signature: The y-parity of the transaction should either be 0 or 1.");
+            }
+        };
+
+        super.appendSignatures(signatureData);
+    }
+
+    /**
+     * Returns a hash string of transaction
+     * @return String
+     */
+    @Override
+    public String getTransactionHash() {
+        // TxHashRLP = 0x01 + encode([chainId, nonce, gasPrice, gas, to, value, data, accessList, signatureYParity, signatureR, signatureS])
+        String rlpEncoded = this.getRLPEncoding();
+        byte[] rlpEncodedBytes = Numeric.hexStringToByteArray(rlpEncoded);
+        byte[] detachedType = Arrays.copyOfRange(rlpEncodedBytes, 1, rlpEncodedBytes.length);
+        return Hash.sha3(Numeric.toHexString(detachedType));
+    }
+
+    /**
+     * Signs to the transaction with a single private key.
+     * It sets Hasher default value.
+     *   - signer : TransactionHasher.getHashForSignature()
+     * @param keyString The private key string.
+     * @return AbstractTransaction
+     * @throws IOException
+     */
+    @Override
+    public AbstractTransaction sign(String keyString) throws IOException {
+        AbstractKeyring keyring = KeyringFactory.createFromPrivateKey(keyString);
+        return this.sign(keyring, TransactionHasher::getHashForSignature);
+    }
+
+    /**
+     * Signs using all private keys used in the role defined in the Keyring instance.
+     * It sets index and Hasher default value.
+     * @param keyring The Keyring instance.
+     * @param signer The function to get hash of transaction.
+     * @return AbstractTransaction
+     * @throws IOException
+     */
+    @Override
+    public AbstractTransaction sign(AbstractKeyring keyring, Function<AbstractTransaction, String> signer) throws IOException {
+        if(TransactionHelper.isEthereumTransaction(this.getType()) && keyring.isDecoupled()) {
+            throw new IllegalArgumentException(this.getType() + " cannot be signed with a decoupled keyring.");
+        }
+
+        if(this.getFrom().equals("0x") || this.getFrom().equals(Utils.DEFAULT_ZERO_ADDRESS) || this.getFrom().isEmpty()){
+            this.setFrom(keyring.getAddress());
+        }
+
+        if(!this.getFrom().toLowerCase().equals(keyring.getAddress().toLowerCase())) {
+            throw new IllegalArgumentException("The from address of the transaction is different with the address of the keyring to use");
+        }
+
+        this.fillTransaction();
+
+        String hash = signer.apply(this);
+        List<SignatureData> sigList = keyring.ecsign(hash, AccountKeyRoleBased.RoleGroup.TRANSACTION.getIndex());
+
+        this.appendSignatures(sigList);
+
+        return this;
+    }
+
+    /**
+     * Signs using all private keys used in the role defined in the Keyring instance.
+     * It sets index and Hasher default value.
+     *   - signer : TransactionHasher.getHashForSignature()
+     * @param keyring The Keyring instance.
+     * @return AbstractTransaction
+     * @throws IOException
+     */
+    @Override
+    public AbstractTransaction sign(AbstractKeyring keyring) throws IOException {
+        return this.sign(keyring, TransactionHasher::getHashForSignature);
+    }
+
+    /**
+     * Signs to the transaction with a single private key.
+     * @param keyString The private key string
+     * @param signer The function to get hash of transaction.
+     * @return AbstractTransaction
+     * @throws IOException
+     */
+    @Override
+    public AbstractTransaction sign(String keyString, Function<AbstractTransaction, String> signer) throws IOException {
+
+        AbstractKeyring keyring = KeyringFactory.createFromPrivateKey(keyString);
+        return this.sign(keyring, signer);
+    }
+
+    /**
+     * Signs to the transaction with a private key in the Keyring instance.
+     * It sets signer to TransactionHasher.getHashForSignature()
+     * @param keyring The Keyring instance.
+     * @param index The index of private key to use in Keyring instance.
+     * @return AbstractTransaction
+     * @throws IOException
+     */
+    @Override
+    public AbstractTransaction sign(AbstractKeyring keyring, int index) throws IOException {
+        return this.sign(keyring, index, TransactionHasher::getHashForSignature);
+    }
+
+    /**
+     * Signs to the transaction with a private key in the Keyring instance.
+     * @param keyring The Keyring instance.
+     * @param index The index of private key to use in Keyring instance.
+     * @param signer The function to get hash of transaction.
+     * @return AbstractTransaction
+     * @throws IOException
+     */
+    @Override
+    public AbstractTransaction sign(AbstractKeyring keyring, int index, Function<AbstractTransaction, String> signer) throws IOException {
+        if(TransactionHelper.isEthereumTransaction(this.getType()) && keyring.isDecoupled()) {
+            throw new IllegalArgumentException(this.getType() + " cannot be signed with a decoupled keyring.");
+        }
+
+        if(this.getFrom().equals("0x") || this.getFrom().equals(Utils.DEFAULT_ZERO_ADDRESS) || this.getFrom().isEmpty()){
+            this.setFrom(keyring.getAddress());
+        }
+
+        if(!this.getFrom().toLowerCase().equals(keyring.getAddress().toLowerCase())) {
+            throw new IllegalArgumentException("The from address of the transaction is different with the address of the keyring to use");
+        }
+
+        this.fillTransaction();
+
+        String hash = signer.apply(this);
+        SignatureData signatureData = keyring.ecsign(hash, AccountKeyRoleBased.RoleGroup.TRANSACTION.getIndex(), index);
+
+        this.appendSignatures(signatureData);
+
+        return this;
+    }
+
+    /**
+     * Getter function for to
+     *
+     * @return String
+     */
+    public String getTo() {
+        return to;
+    }
+
+    /**
+     * Setter function for to
+     *
+     * @param to The account address that will receive the transferred value.
+     */
+    public void setTo(String to) {
+        // "to" field in EthereumAccessList allows null
+        if (to == null || to.isEmpty()) {
+            to = "0x";
+        }
+
+        if (!to.equals("0x") && !Utils.isAddress(to)) {
+            throw new IllegalArgumentException("Invalid address. : " + to);
+        }
+        this.to = to;
+    }
+
+    /**
+     * Getter function for input
+     *
+     * @return String
+     */
+    public String getInput() {
+        return input;
+    }
+
+    /**
+     * Setter function for input
+     *
+     * @param input Data attached to the transaction.
+     */
+    public void setInput(String input) {
+        if (input == null) {
+            throw new IllegalArgumentException("input is missing");
+        }
+
+        if (!Utils.isHex(input)) {
+            throw new IllegalArgumentException("Invalid input : " + input);
+        }
+        this.input = Numeric.prependHexPrefix(input);
+    }
+
+
+    /**
+     * Getter function for value
+     *
+     * @return String
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Setter function for value
+     *
+     * @param value The amount of KLAY in peb to be transferred.
+     */
+    public void setValue(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("value is missing");
+        }
+
+        if (!Utils.isNumber(value)) {
+            throw new IllegalArgumentException("Invalid value : " + value);
+        }
+        this.value = value;
+    }
+
+    /**
+     * Setter function for value
+     *
+     * @param value The amount of KLAY in peb to be transferred.
+     */
+    public void setValue(BigInteger value) {
+        setValue(Numeric.toHexStringWithPrefix(value));
+    }
+
+    /**
+     * Getter function for accessList
+     *
+     * @return accessList Access list is an EIP-2930 access list.
+     */
+    public AccessList getAccessList() {
+        return accessList;
+    }
+
+    /**
+     * Setter function for accessList
+     *
+     * @param accessList Access list is an EIP-2930 access list.
+     */
+    public void setAccessList(AccessList accessList) {
+        if (accessList == null) {
+            accessList = new AccessList();
+        }
+        this.accessList = accessList;
+    }
+}

--- a/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.account.AccountKeyRoleBased;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.transaction.TransactionHasher;
 import com.klaytn.caver.transaction.TransactionHelper;
 import com.klaytn.caver.transaction.utils.AccessList;
@@ -63,6 +64,11 @@ public class EthereumAccessList extends AbstractTransaction {
     AccessList accessList;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * EthereumAccessList Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<EthereumAccessList.Builder> {
@@ -70,6 +76,7 @@ public class EthereumAccessList extends AbstractTransaction {
         private String value = "0x0";
         private String input = "0x";
         private AccessList accessList = new AccessList();
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeEthereumAccessList.toString());
@@ -97,6 +104,16 @@ public class EthereumAccessList extends AbstractTransaction {
 
         public Builder setAccessList(AccessList accessList) {
             this.accessList = accessList;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -148,6 +165,7 @@ public class EthereumAccessList extends AbstractTransaction {
         setValue(builder.value);
         setInput(builder.input);
         setAccessList(builder.accessList);
+        setGasPrice(builder.gasPrice);
     }
 
 
@@ -172,7 +190,6 @@ public class EthereumAccessList extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
@@ -180,7 +197,41 @@ public class EthereumAccessList extends AbstractTransaction {
         setValue(value);
         setInput(input);
         setAccessList(accessList);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     @Override
     public String getRLPEncoding() {
@@ -256,10 +307,77 @@ public class EthereumAccessList extends AbstractTransaction {
         if (!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if (!this.getInput().equals(txObj.getInput())) return false;
         if (!this.getAccessList().equals(txObj.getAccessList())) return false;
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
 
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            EthereumAccessList txObj = (EthereumAccessList) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
 
     /**
      * Decodes a RLP-encoded EthereumAccessList string.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
@@ -330,7 +330,7 @@ public class EthereumAccessList extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             EthereumAccessList txObj = (EthereumAccessList) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
@@ -363,7 +363,7 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedAccountUpdate txObj = (FeeDelegatedAccountUpdate) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
@@ -19,12 +19,16 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,10 +46,16 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
     Account account;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedAccountUpdate Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedAccountUpdate.Builder> {
         Account account;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedAccountUpdate.toString());
@@ -53,6 +63,16 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
 
         public Builder setAccount(Account account) {
             this.account = account;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -95,6 +115,7 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
     public FeeDelegatedAccountUpdate(FeeDelegatedAccountUpdate.Builder builder) {
         super(builder);
         setAccount(builder.account);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -117,13 +138,45 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
                 feePayerSignatures
         );
         setAccount(account);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -293,9 +346,78 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
         if(!this.getAccount().getRLPEncodingAccountKey().equals(feeDelegatedAccountUpdate.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
+        if (!this.getGasPrice().equals(feeDelegatedAccountUpdate.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedAccountUpdate txObj = (FeeDelegatedAccountUpdate) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for Account

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
@@ -378,7 +378,7 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedAccountUpdateWithRatio txObj = (FeeDelegatedAccountUpdateWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
@@ -18,13 +18,17 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,10 +46,16 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
     Account account;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedAccountUpdateWithRatio Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedAccountUpdateWithRatio.Builder> {
         Account account;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedAccountUpdateWithRatio.toString());
@@ -53,6 +63,16 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
 
         public Builder setAccount(Account account) {
             this.account = account;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -96,6 +116,7 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
     public FeeDelegatedAccountUpdateWithRatio(Builder builder) {
         super(builder);
         setAccount(builder.account);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -119,7 +140,6 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -127,7 +147,41 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
                 feeRatio
         );
         setAccount(account);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedAccountUpdateWithRatio string.
@@ -300,9 +354,85 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
         if(!this.getAccount().getRLPEncodingAccountKey().equals(feeDelegatedAccountUpdate.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
+        if (!this.getGasPrice().equals(feeDelegatedAccountUpdate.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedAccountUpdateWithRatio txObj = (FeeDelegatedAccountUpdateWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for Account

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
@@ -19,12 +19,15 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,13 +38,29 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/fee-delegation#txtypefeedelegatedcancel to see more detail.
  */
 public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
+    /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
 
     /**
      * FeeDelegatedCancel Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedCancel.Builder> {
+        String gasPrice = "0x";
+
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedCancel.toString());
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+            return this;
         }
 
         public FeeDelegatedCancel build() {
@@ -81,6 +100,7 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
      */
     public FeeDelegatedCancel(FeeDelegatedCancel.Builder builder) {
         super(builder);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -102,12 +122,44 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
                 feePayerSignatures
         );
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -261,7 +313,85 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
     public boolean compareTxField(AbstractFeeDelegatedTransaction txObj, boolean checkSig) {
         if(!super.compareTxField(txObj, checkSig)) return false;
         if(!(txObj instanceof FeeDelegatedCancel)) return false;
+        FeeDelegatedCancel feeDelegatedCancel = (FeeDelegatedCancel) txObj;
+        if (!this.getGasPrice().equals(feeDelegatedCancel.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedCancel txObj = (FeeDelegatedCancel) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
+
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
@@ -338,7 +338,7 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedCancel txObj = (FeeDelegatedCancel) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
@@ -340,7 +340,7 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedCancelWithRatio txObj = (FeeDelegatedCancelWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
@@ -17,13 +17,17 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,13 +38,29 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedcancelwithratio to see more detail.
  */
 public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTransaction {
+    /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
 
     /**
      * FeeDelegatedCancelWithRatio Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedCancelWithRatio.Builder> {
+        String gasPrice = "0x";
+
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedCancelWithRatio.toString());
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+            return this;
         }
 
         public FeeDelegatedCancelWithRatio build() {
@@ -81,6 +101,7 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
      */
     public FeeDelegatedCancelWithRatio(Builder builder) {
         super(builder);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -97,7 +118,51 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
      * @param feeRatio A fee ratio of the fee payer.
      */
     public FeeDelegatedCancelWithRatio(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio) {
-        super(klaytnCall, TransactionType.TxTypeFeeDelegatedCancelWithRatio.toString(), from, nonce, gas, gasPrice, chainId, signatures, feePayer, feePayerSignatures, feeRatio);
+        super(
+                klaytnCall,
+                TransactionType.TxTypeFeeDelegatedCancelWithRatio.toString(),
+                from,
+                nonce,
+                gas,
+                chainId,
+                signatures,
+                feePayer,
+                feePayerSignatures,
+                feeRatio
+        );
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -257,7 +322,78 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
     public boolean compareTxField(AbstractFeeDelegatedWithRatioTransaction txObj, boolean checkSig) {
         if(!super.compareTxField(txObj, checkSig)) return false;
         if(!(txObj instanceof FeeDelegatedCancelWithRatio)) return false;
+        FeeDelegatedCancelWithRatio feeDelegatedCancelWithRatio = (FeeDelegatedCancelWithRatio) txObj;
+        if (!this.getGasPrice().equals(feeDelegatedCancelWithRatio.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedCancelWithRatio txObj = (FeeDelegatedCancelWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
+
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
@@ -361,7 +361,7 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedChainDataAnchoring txObj = (FeeDelegatedChainDataAnchoring) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,10 +45,16 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedChainDataAnchoring Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedChainDataAnchoring.Builder> {
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedChainDataAnchoring.toString());
@@ -54,6 +62,16 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -96,6 +114,7 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
     public FeeDelegatedChainDataAnchoring(Builder builder) {
         super(builder);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -118,13 +137,45 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
                 feePayerSignatures
         );
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -286,9 +337,85 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
         FeeDelegatedChainDataAnchoring feeDelegatedChainDataAnchoring = (FeeDelegatedChainDataAnchoring)txObj;
 
         if(!this.getInput().equals(feeDelegatedChainDataAnchoring.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedChainDataAnchoring.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedChainDataAnchoring txObj = (FeeDelegatedChainDataAnchoring) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for input

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
@@ -366,7 +366,7 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedChainDataAnchoringWithRatio txObj = (FeeDelegatedChainDataAnchoringWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,10 +44,16 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedChainDataAnchoringWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedChainDataAnchoringWithRatio.Builder> {
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedChainDataAnchoringWithRatio.toString());
@@ -52,6 +61,16 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -95,6 +114,7 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
     public FeeDelegatedChainDataAnchoringWithRatio(Builder builder) {
         super(builder);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -118,7 +138,6 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -126,6 +145,39 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
                 feeRatio
         );
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -290,9 +342,85 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
         FeeDelegatedChainDataAnchoringWithRatio feeDelegatedChainDataAnchoringWithRatio = (FeeDelegatedChainDataAnchoringWithRatio)txObj;
 
         if(!this.getInput().equals(feeDelegatedChainDataAnchoringWithRatio.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedChainDataAnchoringWithRatio.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedChainDataAnchoringWithRatio txObj = (FeeDelegatedChainDataAnchoringWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for input

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
@@ -457,7 +457,7 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractDeploy txObj = (FeeDelegatedSmartContractDeploy) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
@@ -18,6 +18,7 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Utils;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +38,6 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/fee-delegation#txtypefeedelegatedsmartcontractdeploy to see more detail.
  */
 public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
-
     /**
      * The account address that will receive the transferred value.
      */
@@ -65,6 +66,11 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
     String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractDeploy Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedSmartContractDeploy.Builder> {
@@ -73,6 +79,7 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         String input;
         boolean humanReadable = false;
         String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractDeploy.toString());
@@ -110,6 +117,16 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
 
         public Builder setCodeFormat(BigInteger codeFormat) {
             this.codeFormat = Numeric.toHexStringWithPrefix(codeFormat);
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -161,6 +178,7 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         setInput(builder.input);
         setHumanReadable(builder.humanReadable);
         setCodeFormat(builder.codeFormat);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -187,7 +205,6 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -198,6 +215,39 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         setInput(input);
         setHumanReadable(humanReadable);
         setCodeFormat(codeFormat);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -383,9 +433,85 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         if(!this.getInput().equals(feeDelegatedSmartContractDeploy.getInput())) return false;
         if(this.getHumanReadable() != feeDelegatedSmartContractDeploy.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(feeDelegatedSmartContractDeploy.getCodeFormat())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedSmartContractDeploy.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractDeploy txObj = (FeeDelegatedSmartContractDeploy) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
@@ -468,7 +468,7 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractDeployWithRatio txObj = (FeeDelegatedSmartContractDeployWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Utils;
@@ -26,6 +28,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,6 +68,11 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
     String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractDeployWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedSmartContractDeployWithRatio.Builder> {
@@ -73,6 +81,7 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         String input;
         boolean humanReadable = false;
         String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractDeployWithRatio.toString());
@@ -110,6 +119,16 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
 
         public Builder setCodeFormat(BigInteger codeFormat) {
             this.codeFormat = Numeric.toHexStringWithPrefix(codeFormat);
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -161,6 +180,7 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         setInput(builder.input);
         setHumanReadable(builder.humanReadable);
         setCodeFormat(builder.codeFormat);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -188,7 +208,6 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -200,7 +219,41 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         setInput(input);
         setHumanReadable(humanReadable);
         setCodeFormat(codeFormat);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedSmartContractDeployWithRatio string.
@@ -391,9 +444,85 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         if(!this.getInput().equals(feeDelegatedSmartContractDeployWithRatio.getInput())) return false;
         if(this.getHumanReadable() != feeDelegatedSmartContractDeployWithRatio.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(feeDelegatedSmartContractDeployWithRatio.getCodeFormat())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedSmartContractDeployWithRatio.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractDeployWithRatio txObj = (FeeDelegatedSmartContractDeployWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
@@ -408,7 +408,7 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractExecution txObj = (FeeDelegatedSmartContractExecution) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,12 +54,18 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractExecution Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedSmartContractExecution.Builder> {
         String to;
         String value = "0x00";
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractExecution.toString());
@@ -80,6 +88,16 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -126,6 +144,7 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -150,7 +169,6 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -159,6 +177,39 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -333,8 +384,83 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractExecution txObj = (FeeDelegatedSmartContractExecution) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
@@ -412,7 +412,7 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractExecutionWithRatio txObj = (FeeDelegatedSmartContractExecutionWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,12 +50,18 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractExecutionWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedSmartContractExecutionWithRatio.Builder> {
         String to;
         String value = "0x00";
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractExecutionWithRatio.toString());
@@ -75,6 +84,16 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -122,6 +141,7 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -147,7 +167,6 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -157,7 +176,41 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedSmartContractExecutionWithRatio string.
@@ -335,8 +388,83 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         if(!this.getTo().toLowerCase().equals(feeDelegatedSmartContractExecutionWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedSmartContractExecutionWithRatio.getValue()))) return false;
         if(!this.getInput().equals(feeDelegatedSmartContractExecutionWithRatio.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedSmartContractExecutionWithRatio.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractExecutionWithRatio txObj = (FeeDelegatedSmartContractExecutionWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,11 +50,17 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
     String value;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransfer Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedValueTransfer.Builder> {
         String to;
         String value;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransfer.toString());
@@ -70,6 +78,16 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
 
         public Builder setValue(BigInteger value) {
             setValue(Numeric.toHexStringWithPrefix(value));
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -114,6 +132,7 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
         super(builder);
         setTo(builder.to);
         setValue(builder.value);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -137,7 +156,6 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -145,6 +163,39 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
         );
         setTo(to);
         setValue(value);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -315,9 +366,85 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
 
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransfer.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransfer.getValue()))) return false;
+        if(!this.getGasPrice().equals(feeDelegatedValueTransfer.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransfer txObj = (FeeDelegatedValueTransfer) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Setter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
@@ -390,7 +390,7 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransfer txObj = (FeeDelegatedValueTransfer) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
@@ -410,7 +410,7 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransferMemo txObj = (FeeDelegatedValueTransferMemo) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +38,6 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/fee-delegation#txtypefeedelegatedvaluetransfermemo to see more detail.
  */
 public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransaction {
-
     /**
      * The account address that will receive the transferred value.
      */
@@ -53,12 +54,18 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransferMemo Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedValueTransferMemo.Builder> {
         String to;
         String value;
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransferMemo.toString());
@@ -80,6 +87,16 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -126,6 +143,7 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -150,7 +168,6 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -160,7 +177,41 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedValueTransferMemo string.
@@ -335,9 +386,85 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransferMemo txObj = (FeeDelegatedValueTransferMemo) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,12 +55,18 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransferMemo Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedValueTransferMemoWithRatio.Builder> {
         String to;
         String value;
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransferMemoWithRatio.toString());
@@ -79,6 +88,16 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -126,6 +145,7 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -151,7 +171,6 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -161,6 +180,39 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -341,8 +393,83 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransferMemoWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransferMemoWithRatio.getValue()))) return false;
         if(!this.getInput().equals(feeDelegatedValueTransferMemoWithRatio.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedValueTransferMemoWithRatio.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransferMemoWithRatio txObj = (FeeDelegatedValueTransferMemoWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
@@ -417,7 +417,7 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransferMemoWithRatio txObj = (FeeDelegatedValueTransferMemoWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +39,6 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedvaluetransferwithratio to see more detail.
  */
 public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWithRatioTransaction {
-
     /**
      * The account address that will receive the transferred value.
      */
@@ -48,11 +50,17 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
     String value;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransferWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedValueTransferWithRatio.Builder> {
         String to;
         String value;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransferWithRatio.toString());
@@ -70,6 +78,16 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
 
         public Builder setValue(BigInteger value) {
             setValue(Numeric.toHexStringWithPrefix(value));
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -115,6 +133,7 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
         super(builder);
         setTo(builder.to);
         setValue(builder.value);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -139,7 +158,6 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -148,6 +166,39 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
         );
         setTo(to);
         setValue(value);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -322,8 +373,83 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
 
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransferWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransferWithRatio.getValue()))) return false;
+        if(!this.getGasPrice().equals(feeDelegatedValueTransferWithRatio.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransferWithRatio txObj = (FeeDelegatedValueTransferWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
@@ -397,7 +397,7 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransferWithRatio txObj = (FeeDelegatedValueTransferWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
@@ -18,11 +18,13 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,12 +46,18 @@ public class LegacyTransaction extends AbstractTransaction {
     String value;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * LegacyTransaction Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<LegacyTransaction.Builder> {
         private String to = "0x";
         private String value;
         private String input = "0x";
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeLegacyTransaction.toString());
@@ -72,6 +80,16 @@ public class LegacyTransaction extends AbstractTransaction {
 
         public Builder setTo(String to) {
             this.to = to;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -117,6 +135,7 @@ public class LegacyTransaction extends AbstractTransaction {
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -139,14 +158,47 @@ public class LegacyTransaction extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded LegacyTransaction string.
@@ -299,9 +351,71 @@ public class LegacyTransaction extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            LegacyTransaction txObj = (LegacyTransaction) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
@@ -367,7 +367,7 @@ public class LegacyTransaction extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             LegacyTransaction txObj = (LegacyTransaction) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
@@ -396,7 +396,7 @@ public class SmartContractDeploy extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             SmartContractDeploy txObj = (SmartContractDeploy) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
@@ -18,6 +18,7 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Utils;
@@ -25,6 +26,7 @@ import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,6 +66,11 @@ public class SmartContractDeploy extends AbstractTransaction {
     String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * SmartContractDeploy Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<SmartContractDeploy.Builder> {
@@ -72,6 +79,7 @@ public class SmartContractDeploy extends AbstractTransaction {
         String input;
         boolean humanReadable = false;
         String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeSmartContractDeploy.toString());
@@ -109,6 +117,16 @@ public class SmartContractDeploy extends AbstractTransaction {
 
         public Builder setCodeFormat(BigInteger codeFormat) {
             this.codeFormat = Numeric.toHexStringWithPrefix(codeFormat);
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -158,6 +176,7 @@ public class SmartContractDeploy extends AbstractTransaction {
         setInput(builder.input);
         setHumanReadable(builder.humanReadable);
         setCodeFormat(builder.codeFormat);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -182,7 +201,6 @@ public class SmartContractDeploy extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
@@ -191,6 +209,39 @@ public class SmartContractDeploy extends AbstractTransaction {
         setInput(input);
         setHumanReadable(humanReadable);
         setCodeFormat(codeFormat);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -329,9 +380,71 @@ public class SmartContractDeploy extends AbstractTransaction {
         if(!this.getInput().equals(txObj.getInput())) return false;
         if(this.getHumanReadable() != txObj.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(txObj.getCodeFormat())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            SmartContractDeploy txObj = (SmartContractDeploy) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
@@ -348,7 +348,7 @@ public class SmartContractExecution extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             SmartContractExecution txObj = (SmartContractExecution) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
@@ -18,12 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,12 +53,18 @@ public class SmartContractExecution extends AbstractTransaction {
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * SmartContractExecution Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<SmartContractExecution.Builder> {
         String to;
         String value = "0x00";
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeSmartContractExecution.toString());
@@ -79,6 +87,16 @@ public class SmartContractExecution extends AbstractTransaction {
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -124,6 +142,7 @@ public class SmartContractExecution extends AbstractTransaction {
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -146,13 +165,45 @@ public class SmartContractExecution extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -281,9 +332,71 @@ public class SmartContractExecution extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            SmartContractExecution txObj = (SmartContractExecution) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/TransactionType.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/TransactionType.java
@@ -16,6 +16,8 @@
 
 package com.klaytn.caver.transaction.type;
 
+import java.util.Objects;
+
 public enum TransactionType {
     TxTypeLegacyTransaction(0x00),
 
@@ -45,10 +47,12 @@ public enum TransactionType {
 
     TxTypeChainDataAnchoring(0x48),
     TxTypeFeeDelegatedChainDataAnchoring(0x49),
-    TxTypeFeeDelegatedChainDataAnchoringWithRatio(0x4a);
+    TxTypeFeeDelegatedChainDataAnchoringWithRatio(0x4a),
+
+    TxTypeEthereumAccessList(0x7801);
 
     int type;
-    
+
     TransactionType(int type) {
         this.type = type;
     }
@@ -56,4 +60,5 @@ public enum TransactionType {
     public int getType() {
         return type;
     }
+
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransfer.java
@@ -327,7 +327,7 @@ public class ValueTransfer extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             ValueTransfer txObj = (ValueTransfer) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
@@ -18,12 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,12 +53,18 @@ public class ValueTransferMemo extends AbstractTransaction {
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * ValueTransferMemo Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<ValueTransferMemo.Builder> {
         String to;
         String value;
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeValueTransferMemo.toString());
@@ -79,6 +87,16 @@ public class ValueTransferMemo extends AbstractTransaction {
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -123,6 +141,7 @@ public class ValueTransferMemo extends AbstractTransaction {
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -145,13 +164,45 @@ public class ValueTransferMemo extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -280,9 +331,71 @@ public class ValueTransferMemo extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            ValueTransferMemo txObj = (ValueTransferMemo) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
@@ -347,7 +347,7 @@ public class ValueTransferMemo extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             ValueTransferMemo txObj = (ValueTransferMemo) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/wrapper/EthereumAccessListWrapper.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/wrapper/EthereumAccessListWrapper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 The caver-java Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.klaytn.caver.transaction.type.wrapper;
+
+import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.utils.AccessList;
+import com.klaytn.caver.transaction.type.EthereumAccessList;
+import com.klaytn.caver.wallet.keyring.SignatureData;
+
+import java.util.List;
+
+/**
+ * Represents a EthereumAccessListWrapper
+ * 1. This class wraps all of static methods of EthereumAccessList
+ * 2. This class should be accessed via `caver.transaction.ethereumAccessList`
+ */
+public class EthereumAccessListWrapper {
+    /**
+     * Klay RPC instance
+     */
+    private Klay klaytnCall;
+
+    /**
+     * Creates a EthereumAccessListWrapper instance.
+     * @param klaytnCall Klay RPC instance
+     */
+    public EthereumAccessListWrapper(Klay klaytnCall) {
+        this.klaytnCall = klaytnCall;
+    }
+
+    /**
+     * Creates a EthereumAccessList instance derived from a RLP-encoded EthereumAccessList string.
+     * @param rlpEncoded RLP-encoded EthereumAccessList string
+     * @return EthereumAccessList
+     */
+    public EthereumAccessList create(String rlpEncoded) {
+        EthereumAccessList legacyTransaction = EthereumAccessList.decode(rlpEncoded);
+        legacyTransaction.setKlaytnCall(this.klaytnCall);
+        return legacyTransaction;
+    }
+
+    /**
+     * Creates a EthereumAccessList instance derived from a RLP-encoded EthereumAccessList byte array.
+     * @param rlpEncoded RLP-encoded EthereumAccessList byte array.
+     * @return EthereumAccessList
+     */
+    public EthereumAccessList create(byte[] rlpEncoded) {
+        EthereumAccessList legacyTransaction = EthereumAccessList.decode(rlpEncoded);
+        legacyTransaction.setKlaytnCall(this.klaytnCall);
+        return legacyTransaction;
+    }
+
+    /**
+     * Creates a EthereumAccessList instance using EthereumAccessList.Builder
+     * @param builder EthereumAccessList.Builder
+     * @return EthereumAccessList
+     */
+    public EthereumAccessList create(EthereumAccessList.Builder builder) {
+        builder.setKlaytnCall(this.klaytnCall);
+        return EthereumAccessList.create(builder);
+    }
+
+    /**
+     * Create a EthereumAccessList instance.
+     * @param from The address of the sender.
+     * @param nonce A value used to uniquely identify a sender’s transaction.
+     * @param gas The maximum amount of gas the transaction is allowed to use.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     * @param chainId Network ID
+     * @param signatures A Signature list
+     * @param to The account address that will receive the transferred value.
+     * @param input Data attached to the transaction, used for transaction execution.
+     * @param value The amount of KLAY in peb to be transferred.
+     * @param accessList The EIP-2930 access list.
+     * @return EthereumAccessList
+     */
+    public EthereumAccessList create(String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String to, String input, String value, AccessList accessList) {
+        return EthereumAccessList.create(this.klaytnCall, from, nonce, gas, gasPrice, chainId, signatures, to, input, value, accessList);
+    }
+
+    /**
+     * Decodes a RLP-encoded EthereumAccessList string.
+     * @param rlpEncoded RLP-encoded EthereumAccessList string
+     * @return EthereumAccessList
+     */
+    public EthereumAccessList decode(String rlpEncoded) {
+        return EthereumAccessList.decode(rlpEncoded);
+    }
+
+    /**
+     * Decodes a RLP-encoded EthereumAccessList byte array.
+     * @param rlpEncoded RLP-encoded EthereumAccessList byte array.
+     * @return EthereumAccessList
+     */
+    public EthereumAccessList decode(byte[] rlpEncoded) {
+        return EthereumAccessList.decode(rlpEncoded);
+    }
+}

--- a/core/src/main/java/com/klaytn/caver/transaction/wrapper/TransactionWrapper.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/wrapper/TransactionWrapper.java
@@ -40,6 +40,11 @@ public class TransactionWrapper {
     public LegacyTransactionWrapper legacyTransaction;
 
     /**
+     * EthereumAccessListWrapper instance
+     */
+    public EthereumAccessListWrapper ethereumAccessList;
+
+    /**
      * ValueTransferWrapper instance
      */
     public ValueTransferWrapper valueTransfer;
@@ -157,6 +162,7 @@ public class TransactionWrapper {
         this.klay = klaytnCall;
 
         this.legacyTransaction = new LegacyTransactionWrapper(klaytnCall);
+        this.ethereumAccessList = new EthereumAccessListWrapper(klaytnCall);
 
         this.valueTransfer = new ValueTransferWrapper(klaytnCall);
         this.feeDelegatedValueTransfer = new FeeDelegatedValueTransferWrapper(klaytnCall);

--- a/core/src/main/java/com/klaytn/caver/wallet/keyring/SignatureData.java
+++ b/core/src/main/java/com/klaytn/caver/wallet/keyring/SignatureData.java
@@ -18,6 +18,8 @@ package com.klaytn.caver.wallet.keyring;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.klaytn.caver.transaction.type.TransactionType;
+import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import org.web3j.rlp.RlpList;
 import org.web3j.rlp.RlpString;
@@ -68,6 +70,10 @@ public class SignatureData {
      * @param s The ECDSA Signature data S
      */
     public SignatureData(byte[] v, byte[] r, byte[] s) {
+        if (v.length == 0) {
+            // It handles when given v value was 0(represented "0x80" in rlp encoded).
+            v = BytesUtils.concat(new byte[]{0x0}, v);
+        }
         this.v = Numeric.toHexString(v);
         this.r = Numeric.toHexString(r);
         this.s = Numeric.toHexString(s);
@@ -160,8 +166,19 @@ public class SignatureData {
         byte[] r = Numeric.hexStringToByteArray(getR());
         byte[] s = Numeric.hexStringToByteArray(getS());
 
+        RlpString rlpV;
+        byte[] trimmedV = Bytes.trimLeadingZeroes(v);
+        if (trimmedV[0] == 0) {
+            // If v value is "0x0", the shape of trimmedV is [0x0] (have 1 element).
+            // If we create rlpV by using RlpString.create(byte[]{0x0}), it is encoded as `0x00` but
+            // v value is integer by its spec and integer 0 must be encoded as 0x80.
+            rlpV = RlpString.create(BigInteger.valueOf(0));
+        } else {
+            rlpV = RlpString.create(trimmedV);
+        }
+
         return new RlpList(
-                RlpString.create(Bytes.trimLeadingZeroes(v)),
+                rlpV,
                 RlpString.create(Bytes.trimLeadingZeroes(r)),
                 RlpString.create(Bytes.trimLeadingZeroes(s))
         );

--- a/core/src/test/java/com/klaytn/caver/common/methods/response/TransactionReceiptTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/methods/response/TransactionReceiptTest.java
@@ -1,0 +1,65 @@
+package com.klaytn.caver.common.methods.response;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.klaytn.caver.methods.response.TransactionReceipt;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+public class TransactionReceiptTest {
+    public static String objectToString(Object value) throws JsonProcessingException {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString(value);
+    }
+
+    public static class ethereumAccessListTest {
+        @Test
+        public void deserializeTest() throws IOException {
+            String ethereumAccessListReceiptJson = "{\n" +
+                    "  \"accessList\": [\n" +
+                    "    {\n" +
+                    "      \"address\": \"0xca7a99380131e6c76cfa622396347107aeedca2d\",\n" +
+                    "      \"storageKeys\": [\n" +
+                    "        \"0x0709c257577296fac29c739dad24e55b70a260497283cf9885ab67b4daa9b67f\"\n" +
+                    "      ]\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"blockHash\": \"0x43459f308ba7e54976491922c062cad07c70798a24de403ee830f2c36f0eb59e\",\n" +
+                    "  \"blockNumber\": 91,\n" +
+                    "  \"chainID\": \"0x7e3\",\n" +
+                    "  \"contractAddress\": null,\n" +
+                    "  \"from\": \"0xca7a99380131e6c76cfa622396347107aeedca2d\",\n" +
+                    "  \"gas\": \"0xf423f\",\n" +
+                    "  \"gasPrice\": \"0x5d21dba00\",\n" +
+                    "  \"gasUsed\": 25300,\n" +
+                    "  \"input\": \"0x\",\n" +
+                    "  \"logs\": [],\n" +
+                    "  \"logsBloom\": \"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\n" +
+                    "  \"nonce\": \"0x0\",\n" +
+                    "  \"senderTxHash\": \"0x658b0aa2b625a1a0c3c9fe54e7f5f51ba962aeb7e62ae2ed338597058a603d71\",\n" +
+                    "  \"signatures\": [\n" +
+                    "    {\n" +
+                    "      \"R\": \"0x1c064e8434def2a74b129dfaa5bd98e8fb8402fc5db284ecdd6807351681ba75\",\n" +
+                    "      \"S\": \"0x3515882ee8d0d3a59c3075eca9748695f0a3e9a7f52b7e4987950eef52bbb42\",\n" +
+                    "      \"V\": \"0x1\"\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"status\": \"0x1\",\n" +
+                    "  \"to\": \"0x8c9f4468ae04fb3d79c80f6eacf0e4e1dd21deee\",\n" +
+                    "  \"transactionHash\": \"0x658b0aa2b625a1a0c3c9fe54e7f5f51ba962aeb7e62ae2ed338597058a603d71\",\n" +
+                    "  \"transactionIndex\": 0,\n" +
+                    "  \"type\": \"TxTypeEthereumAccessList\",\n" +
+                    "  \"typeInt\": 30721,\n" +
+                    "  \"value\": \"0x1\"\n" +
+                    "}";
+            ObjectMapper objectMapper = new ObjectMapper();
+            Reader reader = new StringReader(ethereumAccessListReceiptJson);
+            TransactionReceipt.TransactionReceiptData transactionReceiptData = objectMapper.readValue(reader, TransactionReceipt.TransactionReceiptData.class);
+            System.out.println(objectToString(transactionReceiptData));
+        }
+    }
+}

--- a/core/src/test/java/com/klaytn/caver/common/methods/response/TransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/methods/response/TransactionTest.java
@@ -1,0 +1,64 @@
+package com.klaytn.caver.common.methods.response;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.klaytn.caver.methods.response.Transaction;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+@RunWith(Enclosed.class)
+public class TransactionTest {
+    public static String objectToString(Object value) throws JsonProcessingException {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString(value);
+    }
+
+    public static class ethereumAccessListTest {
+        @Test
+        public void deserializeTest() throws IOException {
+            String ethereumAccessListJson = "{\n" +
+                    "  \"accessList\": [\n" +
+                    "    {\n" +
+                    "      \"address\": \"0xca7a99380131e6c76cfa622396347107aeedca2d\",\n" +
+                    "      \"storageKeys\": [\n" +
+                    "        \"0x0709c257577296fac29c739dad24e55b70a260497283cf9885ab67b4daa9b67f\"\n" +
+                    "      ]\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"blockHash\": \"0x43459f308ba7e54976491922c062cad07c70798a24de403ee830f2c36f0eb59e\",\n" +
+                    "  \"blockNumber\": 91,\n" +
+                    "  \"chainID\": \"0x7e3\",\n" +
+                    "  \"from\": \"0xca7a99380131e6c76cfa622396347107aeedca2d\",\n" +
+                    "  \"gas\": 999999,\n" +
+                    "  \"gasPrice\": 25000000000,\n" +
+                    "  \"hash\": \"0x658b0aa2b625a1a0c3c9fe54e7f5f51ba962aeb7e62ae2ed338597058a603d71\",\n" +
+                    "  \"input\": \"0x\",\n" +
+                    "  \"nonce\": 0,\n" +
+                    "  \"senderTxHash\": \"0x658b0aa2b625a1a0c3c9fe54e7f5f51ba962aeb7e62ae2ed338597058a603d71\",\n" +
+                    "  \"signatures\": [\n" +
+                    "    {\n" +
+                    "      \"R\": \"0x1c064e8434def2a74b129dfaa5bd98e8fb8402fc5db284ecdd6807351681ba75\",\n" +
+                    "      \"S\": \"0x3515882ee8d0d3a59c3075eca9748695f0a3e9a7f52b7e4987950eef52bbb42\",\n" +
+                    "      \"V\": \"0x1\"\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"to\": \"0x8c9f4468ae04fb3d79c80f6eacf0e4e1dd21deee\",\n" +
+                    "  \"transactionIndex\": 0,\n" +
+                    "  \"type\": \"TxTypeEthereumAccessList\",\n" +
+                    "  \"typeInt\": 30721,\n" +
+                    "  \"value\": 1\n" +
+                    "}";
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            Reader reader = new StringReader(ethereumAccessListJson);
+            Transaction.TransactionData transactionData = objectMapper.readValue(reader, Transaction.TransactionData.class);
+            System.out.println(objectToString(transactionData));
+        }
+    }
+}

--- a/core/src/test/java/com/klaytn/caver/common/transaction/EthereumAccessListTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/EthereumAccessListTest.java
@@ -1,0 +1,1671 @@
+/*
+ * Copyright 2022 The caver-java Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.klaytn.caver.common.transaction;
+
+import com.klaytn.caver.Caver;
+import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionHasher;
+import com.klaytn.caver.transaction.TxPropertyBuilder;
+import com.klaytn.caver.transaction.type.EthereumAccessList;
+import com.klaytn.caver.transaction.type.TransactionType;
+import com.klaytn.caver.transaction.utils.AccessList;
+import com.klaytn.caver.transaction.utils.AccessTuple;
+import com.klaytn.caver.wallet.keyring.AbstractKeyring;
+import com.klaytn.caver.wallet.keyring.SignatureData;
+import org.junit.*;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.web3j.utils.Numeric;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(Enclosed.class)
+public class EthereumAccessListTest {
+
+    public static class createInstance {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";
+        String nonce = "0x4D2";
+        String gas = "0xf4240";
+        String gasPrice = "0x19";
+        String from = "0x";
+        String to = "0x7b65b75d204abed71587c9e519a89277766ee1d0";
+        String chainID = "0x1";
+        String input = "0x31323334";
+        String value = "0xa";
+        AccessList accessList = new AccessList(
+                Arrays.asList(
+                        new AccessTuple(
+                                "0x2c8ad0ea2e0781db8b8c9242e07de3a5beabb71a",
+                                Arrays.asList(
+                                        "0x4f42391603e79b2a90c3fbfc070c995eb1163e0ac00fb4e8f3da2dc81c451b98",
+                                        "0xc4a32abdf1905059fdfc304aae1e8924279a36b2a6428552237f590156ed7717"
+                                )
+                        ))
+        );
+
+        Caver caver = new Caver(Caver.DEFAULT_URL);
+
+        @Test
+        public void createInstance() throws IOException {
+            AbstractKeyring keyring = caver.wallet.keyring.createFromPrivateKey(privateKey);
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(keyring.getAddress())
+                            .setNonce("0x")
+                            .setGas(gas)
+                            .setGasPrice("0x")
+                            .setChainId("0x")
+                            .setTo(to)
+                            .setInput(input)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+
+            assertNotNull(ethereumAccessList);
+
+            ethereumAccessList.fillTransaction();
+            assertNotNull(ethereumAccessList.getNonce());
+            assertNotNull(ethereumAccessList.getGasPrice());
+            assertNotNull(ethereumAccessList.getChainId());
+            assertEquals(accessList, ethereumAccessList.getAccessList());
+            assertEquals(TransactionType.TxTypeEthereumAccessList.toString(), ethereumAccessList.getType());
+        }
+
+        @Test
+        public void throwException_invalid_value() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("Invalid value");
+
+            String value = "invalid";
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(from)
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setInput(input)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+        }
+
+        @Test
+        public void throwException_invalid_To() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("Invalid address.");
+
+            String to = "invalid";
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(from)
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setInput(input)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+        }
+
+        @Test
+        public void throwException_missingGas() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("gas is missing");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(from)
+                            .setNonce(nonce)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setInput(input)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+        }
+    }
+
+    public static class createInstanceBuilder {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";
+        static String nonce = "0x4D2";
+        static String gas = "0xf4240";
+        static String gasPrice = "0x19";
+        static String to = "0x7b65b75d204abed71587c9e519a89277766ee1d0";
+        static String chainID = "0x1";
+        static String input = "0x31323334";
+        static String value = "0xa";
+        AccessList accessList = new AccessList(
+                Arrays.asList(
+                        new AccessTuple(
+                                "0x2c8ad0ea2e0781db8b8c9242e07de3a5beabb71a",
+                                Arrays.asList(
+                                        "0x4f42391603e79b2a90c3fbfc070c995eb1163e0ac00fb4e8f3da2dc81c451b98",
+                                        "0xc4a32abdf1905059fdfc304aae1e8924279a36b2a6428552237f590156ed7717"
+                                )
+                        ))
+        );
+
+        @Test
+        public void BuilderTest() {
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setNonce(nonce)
+                    .setGas(gas)
+                    .setGasPrice(gasPrice)
+                    .setChainId(chainID)
+                    .setInput(input)
+                    .setValue(value)
+                    .setTo(to)
+                    .setAccessList(accessList)
+                    .build();
+
+            assertNotNull(ethereumAccessList);
+            assertEquals(TransactionType.TxTypeEthereumAccessList.toString(), ethereumAccessList.getType());
+        }
+
+        @Test
+        public void BuilderTestWithBigInteger() {
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setNonce(nonce)
+                    .setGas(gas)
+                    .setGasPrice(Numeric.toBigInt(gasPrice))
+                    .setChainId(Numeric.toBigInt(chainID))
+                    .setInput(input)
+                    .setValue(Numeric.toBigInt(value))
+                    .setTo(to)
+                    .setAccessList(accessList)
+                    .build();
+
+            assertEquals(gas, ethereumAccessList.getGas());
+            assertEquals(gasPrice, ethereumAccessList.getGasPrice());
+            assertEquals(chainID, ethereumAccessList.getChainId());
+            assertEquals(value, ethereumAccessList.getValue());
+            assertEquals(accessList, ethereumAccessList.getAccessList());
+        }
+
+        @Test
+        public void BuilderTestRPC() throws IOException {
+            String gas = "0x0f4240";
+            String to = "7b65b75d204abed71587c9e519a89277766ee1d0";
+            String input = "0x31323334";
+            String value = "0x0a";
+
+            Caver caver = new Caver(Caver.DEFAULT_URL);
+            AbstractKeyring keyring = caver.wallet.keyring.createFromPrivateKey(privateKey);
+
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setKlaytnCall(caver.rpc.getKlay())
+                    .setGas(gas)
+                    .setInput(input)
+                    .setValue(value)
+                    .setFrom(keyring.getAddress()) // For Test. It automatically filled when executed EthereumAccessList.signWithKey or signWithKeysTest.
+                    .setTo(to)
+                    .setAccessList(accessList)
+                    .build();
+
+            ethereumAccessList.fillTransaction();
+            assertNotNull(ethereumAccessList.getNonce());
+            assertNotNull(ethereumAccessList.getGasPrice());
+            assertNotNull(ethereumAccessList.getChainId());
+            assertNotNull(ethereumAccessList.getAccessList());
+        }
+
+        @Test
+        public void throwException_invalid_value() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("Invalid value");
+
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setNonce(nonce)
+                    .setGas(gas)
+                    .setGasPrice(gasPrice)
+                    .setChainId(chainID)
+                    .setInput(input)
+                    .setTo(to)
+                    .setValue("0x")
+                    .setAccessList(accessList)
+                    .build();
+        }
+
+        @Test
+        public void throwException_invalid_value2() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("Invalid value");
+
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setNonce(nonce)
+                    .setGas(gas)
+                    .setGasPrice(gasPrice)
+                    .setChainId(chainID)
+                    .setInput(input)
+                    .setTo(to)
+                    .setValue("invalid")
+                    .build();
+        }
+
+        @Test
+        public void throwException_invalid_To() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("Invalid address.");
+
+            String gas = "0xf4240";
+            String to = "invalid";
+            String input = "0x31323334";
+            String value = "0xa";
+
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setNonce(nonce)
+                    .setGas(gas)
+                    .setGasPrice(gasPrice)
+                    .setChainId(chainID)
+                    .setInput(input)
+                    .setValue(value)
+                    .setTo(to)
+                    .setAccessList(accessList)
+                    .build();
+        }
+
+        @Test
+        public void throwException_missingGas() {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("gas is missing");
+
+            EthereumAccessList ethereumAccessList = new EthereumAccessList.Builder()
+                    .setNonce(nonce)
+                    .setGasPrice(gasPrice)
+                    .setChainId(chainID)
+                    .setInput(input)
+                    .setValue(value)
+                    .setTo(to)
+                    .setAccessList(accessList)
+                    .build();
+        }
+    }
+
+    public static class getRLPEncodingAndDecodingTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+
+        @Test
+        public void getRLPEncodingAndDecoding() {
+            String gas = "0x1e241";
+            String gasPrice = "0x0a";
+            String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+            String chainID = "0x1";
+            String input = "0x616263646566";
+            String value = "0x0";
+            AccessList accessList1 = new AccessList(Arrays.asList(
+                    new AccessTuple("0x0000000000000000000000000000000000000001",
+                            Arrays.asList("0x0000000000000000000000000000000000000000000000000000000000000000"))
+            ));
+            AccessList accessList2 = new AccessList(Arrays.asList(
+                    new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                            Arrays.asList(
+                                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            ))
+            ));
+            AccessList accessList3 = new AccessList(Arrays.asList(
+                    new AccessTuple("0x0000000000000000000000000000000000000001",
+                            Arrays.asList(
+                                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                            )),
+                    new AccessTuple("0x0000000000000000000000000000000000000002",
+                            Arrays.asList(
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            )),
+                    new AccessTuple("0x0000000000000000000000000000000000000003",
+                            Arrays.asList(
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            ))
+            ));
+
+            SignatureData signatureData1 = new SignatureData(
+                    Numeric.hexStringToByteArray("0x01"),
+                    Numeric.hexStringToByteArray("0x5d2368dff6ab943d3467558de70805d5b6a4367ab94b1ee8a7ae53e4e0f68293"),
+                    Numeric.hexStringToByteArray("0x1d68f38dce681c32cd001ca155b2b27e26ddd788b4bdaaf355181c626805ec7f")
+            );
+            SignatureData signatureData2 = new SignatureData(
+                    Numeric.hexStringToByteArray("0x01"),
+                    Numeric.hexStringToByteArray("0x19676433856a1bd3650e22c210e20c7efdedf1d4f555f1ab6eb7845024f52d99"),
+                    Numeric.hexStringToByteArray("0x70feddce085399eb085b55254fbc8bb5bf912464316b20c3be39bca9015da235")
+            );
+            SignatureData signatureData3 = new SignatureData(
+                    Numeric.hexStringToByteArray("0x01"),
+                    Numeric.hexStringToByteArray("0x3966e6b3297cbcfdbb3e1e3ede1b80dea99d9d01983fc32e337d785fe4445973"),
+                    Numeric.hexStringToByteArray("0x49e25fcda7c8d5517181e2afcf13d2dff77dc33884b512fd1f1cd0770bcd0c59")
+            );
+            SignatureData signatureData4 = new SignatureData(
+                    Numeric.hexStringToByteArray("0x01"),
+                    Numeric.hexStringToByteArray("0x5d6d9bc7bb01b05db25f5f2e4a995a4970124387293694f0fd8bdda95bc6e7f4"),
+                    Numeric.hexStringToByteArray("0x782feaf0460341b320710ef7a4f07167d551fd897775af5ec2f1dea095e99cb")
+            );
+
+            // Test-1: encoding EthereumAccessList which have an address and a storage key.
+            String expectedRLP = "0x7801f88701040a8301e241808080f838f7940000000000000000000000000000000000000001e1a0000000000000000000000000000000000000000000000000000000000000000001a05d2368dff6ab943d3467558de70805d5b6a4367ab94b1ee8a7ae53e4e0f68293a01d68f38dce681c32cd001ca155b2b27e26ddd788b4bdaaf355181c626805ec7f";
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(null)
+                            .setNonce("0x4")
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setAccessList(accessList1)
+                            .setSignatures(signatureData1)
+            );
+            assertEquals(expectedRLP, ethereumAccessList.getRLPEncoding());
+            // Test-1: decoding
+            EthereumAccessList decodedEthereumAccessList = (EthereumAccessList) caver.transaction.decode(expectedRLP);
+            assertTrue(ethereumAccessList.compareTxField(decodedEthereumAccessList, true));
+
+            // Test-2: encoding EthereumAccessList which have many storageKeys
+            expectedRLP = "0x7801f8df01040a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d878080f87cf87a94284e47e6130523b2507ba38cea17dd40a20a0cd0f863a00000000000000000000000000000000000000000000000000000000000000000a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f098368101a019676433856a1bd3650e22c210e20c7efdedf1d4f555f1ab6eb7845024f52d99a070feddce085399eb085b55254fbc8bb5bf912464316b20c3be39bca9015da235";
+            ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(null)
+                            .setTo(to)
+                            .setNonce(BigInteger.valueOf(4))
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setAccessList(accessList2)
+                            .setSignatures(signatureData2)
+            );
+            assertEquals(expectedRLP, ethereumAccessList.getRLPEncoding());
+            // Test-2: decoding
+            decodedEthereumAccessList = (EthereumAccessList) caver.transaction.decode(expectedRLP);
+            assertTrue(ethereumAccessList.compareTxField(decodedEthereumAccessList, true));
+
+            // Test-3: encoding EthereumAccessList which have empty accessList
+            expectedRLP = "0x7801f86801030a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d878086616263646566c001a03966e6b3297cbcfdbb3e1e3ede1b80dea99d9d01983fc32e337d785fe4445973a049e25fcda7c8d5517181e2afcf13d2dff77dc33884b512fd1f1cd0770bcd0c59";
+            ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(null)
+                            .setTo(to)
+                            .setNonce(BigInteger.valueOf(3))
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setAccessList(null)
+                            .setInput(input)
+                            .setSignatures(signatureData3)
+            );
+            assertEquals(expectedRLP, ethereumAccessList.getRLPEncoding());
+            // Test-3: decoding
+            decodedEthereumAccessList = (EthereumAccessList) caver.transaction.decode(expectedRLP);
+            assertTrue(ethereumAccessList.compareTxField(decodedEthereumAccessList, true));
+
+            // Test-4: encoding EthereumAccessList which have many accessList
+            expectedRLP = "0x7801f9013d01040a8301e241808080f8eef7940000000000000000000000000000000000000001e1a00000000000000000000000000000000000000000000000000000000000000000f859940000000000000000000000000000000000000002f842a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681f859940000000000000000000000000000000000000003f842a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f098368101a05d6d9bc7bb01b05db25f5f2e4a995a4970124387293694f0fd8bdda95bc6e7f4a00782feaf0460341b320710ef7a4f07167d551fd897775af5ec2f1dea095e99cb";
+            ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(null)
+                            .setNonce(BigInteger.valueOf(4))
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setAccessList(accessList3)
+                            .setSignatures(signatureData4)
+            );
+            assertEquals(expectedRLP, ethereumAccessList.getRLPEncoding());
+            // Test-4: decoding
+            decodedEthereumAccessList = (EthereumAccessList) caver.transaction.decode(expectedRLP);
+            assertTrue(ethereumAccessList.compareTxField(decodedEthereumAccessList, true));
+        }
+
+        @Test
+        public void getRLPEncodingAndDecodingYParity() {
+            // 0 y-parity
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setTo("0xc6779d72a88bec1a03bbb83cf028d95ff5f32f5b")
+                            .setValue("0x1")
+                            .setGas("0x9c40")
+                            .setNonce("0x1a")
+                            .setGasPrice("0x5d21dba00")
+                            .setChainId("0x2710")
+                            .setInput("0xa9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039")
+                            .setAccessList(caver.transaction.utils.accessList.create(Arrays.asList(
+                                caver.transaction.utils.accessTuple.create(
+                                        "0xac9ba2a7fb8572e971bcac01a5b58934b385a172",
+                                        Arrays.asList(
+                                            "0x0000000000000000000000000000000000000000000000000000000000000003",
+                                            "0x0000000000000000000000000000000000000000000000000000000000000007"
+                                        )
+                                )
+                            )))
+                            .setSignatures(new SignatureData(
+                                    "0x00",
+                                    "0x43ff73938e019e13dcc48c9ff1a46d9f1f081512351cf7b0eca49dbf74047848",
+                                    "0x17a9816ca1446f51e0d6eb8c406a52758feb83b234128e4cfcaeaa8419f706af"
+                            ))
+            );
+            String rlpEncoded = ethereumAccessList.getRLPEncoding();
+            Assert.assertEquals("0x7801f901098227101a8505d21dba00829c4094c6779d72a88bec1a03bbb83cf028d95ff5f32f5b01b844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f85bf85994ac9ba2a7fb8572e971bcac01a5b58934b385a172f842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000780a043ff73938e019e13dcc48c9ff1a46d9f1f081512351cf7b0eca49dbf74047848a017a9816ca1446f51e0d6eb8c406a52758feb83b234128e4cfcaeaa8419f706af", rlpEncoded);
+            EthereumAccessList decodedEthereumAccessList = (EthereumAccessList) caver.transaction.decode(rlpEncoded);
+            assertTrue(ethereumAccessList.compareTxField(decodedEthereumAccessList, true));
+
+            // 1 y-parity
+            ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setTo("0xc5fb1386b60160614a8151dcd4b0ae41325d1cb8")
+                            .setValue("0x1")
+                            .setGas("0x9c40")
+                            .setNonce("0x23")
+                            .setGasPrice("0x5d21dba00")
+                            .setChainId("0x2710")
+                            .setInput("0xa9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039")
+                            .setAccessList(caver.transaction.utils.accessList.create(Arrays.asList(
+                                    caver.transaction.utils.accessTuple.create(
+                                            "0x5430192ae264b3feff967fc08982b9c6f5694023",
+                                            Arrays.asList(
+                                                    "0x0000000000000000000000000000000000000000000000000000000000000003",
+                                                    "0x0000000000000000000000000000000000000000000000000000000000000007"
+                                            )
+                                    )
+                            )))
+                            .setSignatures(new SignatureData(
+                                    "0x01",
+                                    "0x5ac25e47591243af2d6b8e7f54d608e9e0e0aeb5194d34c17852bd7e376f4857",
+                                    "0x095a40394f33e95cce9695d5badf4270f4cc8aff0b5395cefc3a0fe213be1f30"
+                            ))
+            );
+
+            rlpEncoded = ethereumAccessList.getRLPEncoding();
+            Assert.assertEquals("0x7801f90109822710238505d21dba00829c4094c5fb1386b60160614a8151dcd4b0ae41325d1cb801b844a9059cbb0000000000000000000000008a4c9c443bb0645df646a2d5bb55def0ed1e885a0000000000000000000000000000000000000000000000000000000000003039f85bf859945430192ae264b3feff967fc08982b9c6f5694023f842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000000000701a05ac25e47591243af2d6b8e7f54d608e9e0e0aeb5194d34c17852bd7e376f4857a0095a40394f33e95cce9695d5badf4270f4cc8aff0b5395cefc3a0fe213be1f30", ethereumAccessList.getRLPEncoding());
+            decodedEthereumAccessList = (EthereumAccessList) caver.transaction.decode(rlpEncoded);
+            assertTrue(ethereumAccessList.compareTxField(decodedEthereumAccessList, true));
+        }
+
+        @Test
+        public void throwException_NoNonce() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            String gas = "0xf4240";
+            String gasPrice = "0x19";
+            String to = "0x7b65b75d204abed71587c9e519a89277766ee1d0";
+            String chainID = "0x1";
+            String input = "0x31323334";
+            String value = "0xa";
+
+            SignatureData signatureData = new SignatureData(
+                    Numeric.hexStringToByteArray("0x1"),
+                    Numeric.hexStringToByteArray("0xb2a5a15550ec298dc7dddde3774429ed75f864c82caeb5ee24399649ad731be9"),
+                    Numeric.hexStringToByteArray("0x29da1014d16f2011b3307f7bbe1035b6e699a4204fc416c763def6cefd976567")
+            );
+
+            List<SignatureData> list = new ArrayList<>();
+            list.add(signatureData);
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setSignatures(list)
+                            .setTo(to)
+                            .setAccessList(null)
+            );
+
+            ethereumAccessList.getRLPEncoding();
+        }
+
+        @Test
+        public void throwException_NoGasPrice() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            String nonce = "0x4D2";
+            String gas = "0xf4240";
+            String to = "0x7b65b75d204abed71587c9e519a89277766ee1d0";
+            String chainID = "0x1";
+            String input = "0x31323334";
+            String value = "0xa";
+
+            SignatureData signatureData = new SignatureData(
+                    Numeric.hexStringToByteArray("0x0"),
+                    Numeric.hexStringToByteArray("0xb2a5a15550ec298dc7dddde3774429ed75f864c82caeb5ee24399649ad731be9"),
+                    Numeric.hexStringToByteArray("0x29da1014d16f2011b3307f7bbe1035b6e699a4204fc416c763def6cefd976567")
+            );
+
+            List<SignatureData> list = new ArrayList<>();
+            list.add(signatureData);
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setSignatures(list)
+                            .setTo(to)
+                            .setAccessList(null)
+            );
+
+            ethereumAccessList.getRLPEncoding();
+        }
+
+        @Test
+        public void throwException_NoChainId() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            String nonce = "0x4D2";
+            String gas = "0xf4240";
+            String gasPrice = "0x10";
+            String to = "0x7b65b75d204abed71587c9e519a89277766ee1d0";
+            String input = "0x31323334";
+            String value = "0xa";
+
+            SignatureData signatureData = new SignatureData(
+                    Numeric.hexStringToByteArray("0x0"),
+                    Numeric.hexStringToByteArray("0xb2a5a15550ec298dc7dddde3774429ed75f864c82caeb5ee24399649ad731be9"),
+                    Numeric.hexStringToByteArray("0x29da1014d16f2011b3307f7bbe1035b6e699a4204fc416c763def6cefd976567")
+            );
+
+            List<SignatureData> list = new ArrayList<>();
+            list.add(signatureData);
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setValue(value)
+                            .setInput(input)
+                            .setSignatures(list)
+                            .setTo(to)
+                            .setAccessList(null)
+            );
+
+            ethereumAccessList.getRLPEncoding();
+        }
+
+
+    }
+
+    public static class getTransactionHashTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+        static String gas = "0x1e241";
+        static String gasPrice = "0x0a";
+        static String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+        static String chainID = "0x1";
+        static String input = "0x616263646566";
+        static String value = "0x0";
+        static String nonce = "0x4";
+
+        static AccessList accessList = new AccessList(Arrays.asList(
+                new AccessTuple("0x0000000000000000000000000000000000000001",
+                        Arrays.asList(
+                                "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        )),
+                new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                        Arrays.asList(
+                                "0xd2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761",
+                                "0xd2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7c"
+                        )),
+                new AccessTuple("0x0000000000000000000000000000000000000003",
+                        Arrays.asList(
+                                "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                        ))
+        ));
+
+        static SignatureData signatureData = new SignatureData(
+                Numeric.hexStringToByteArray("0x01"),
+                Numeric.hexStringToByteArray("0x26e8a6755fbf9d8d32271753c332718825881fef855e7f9e4868e2d16f908caa"),
+                Numeric.hexStringToByteArray("0x412c0e1dc1fe87fcc7b262be995701dc0606038844f8a0da1eaddef965d8fc2b")
+        );
+
+        @Test
+        public void getTransactionHash() {
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+            String expected = "0x5f4484fe404d9e5b3c100d1b67aa5633daab5d516267bf8af03550644e2d7378";
+            String txHash = ethereumAccessList.getTransactionHash();
+
+            assertEquals(expected, txHash);
+        }
+
+        @Test
+        public void throwException_NotDefined_Nonce() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+
+            ethereumAccessList.getTransactionHash();
+        }
+
+        @Test
+        public void throwException_NotDefined_GasPrice() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setNonce(nonce)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+            ethereumAccessList.getRawTransaction();
+        }
+
+        @Test
+        public void throwException_NotDefined_ChainId() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setNonce(nonce)
+                            .setGasPrice(gasPrice)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+            ethereumAccessList.getTransactionHash();
+        }
+    }
+
+    public static class getSenderTxHashTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+        static String gas = "0x1e241";
+        static String gasPrice = "0x0a";
+        static String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+        static String chainID = "0x1";
+        static String input = "0x616263646566";
+        static String value = "0x0";
+        static String nonce = "0x4";
+
+        static AccessList accessList = new AccessList(Arrays.asList(
+                new AccessTuple("0x0000000000000000000000000000000000000001",
+                        Arrays.asList(
+                                "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        )),
+                new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                        Arrays.asList(
+                                "0xd2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761",
+                                "0xd2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7c"
+                        )),
+                new AccessTuple("0x0000000000000000000000000000000000000003",
+                        Arrays.asList(
+                                "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                        ))
+        ));
+
+        static SignatureData signatureData = new SignatureData(
+                Numeric.hexStringToByteArray("0x01"),
+                Numeric.hexStringToByteArray("0x26e8a6755fbf9d8d32271753c332718825881fef855e7f9e4868e2d16f908caa"),
+                Numeric.hexStringToByteArray("0x412c0e1dc1fe87fcc7b262be995701dc0606038844f8a0da1eaddef965d8fc2b")
+        );
+
+        @Test
+        public void getTransactionHash() {
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+            String expected = "0x5f4484fe404d9e5b3c100d1b67aa5633daab5d516267bf8af03550644e2d7378";
+            String txHash = ethereumAccessList.getSenderTxHash();
+
+            assertEquals(expected, txHash);
+        }
+
+        @Test
+        public void throwException_NotDefined_Nonce() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+
+            ethereumAccessList.getSenderTxHash();
+        }
+
+        @Test
+        public void throwException_NotDefined_GasPrice() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setNonce(nonce)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+            ethereumAccessList.getSenderTxHash();
+        }
+
+        @Test
+        public void throwException_NotDefined_ChainId() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setNonce(nonce)
+                            .setGasPrice(gasPrice)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+            ethereumAccessList.getSenderTxHash();
+        }
+    }
+
+    public static class combineSignatureTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+;
+        @Test
+        public void combineSignature() {
+            String gas = "0x1e241";
+            String gasPrice = "0x0a";
+            String chainID = "0x1";
+            String nonce = "0x4";
+            AccessList accessList = new AccessList(Arrays.asList(
+                    new AccessTuple("0x0000000000000000000000000000000000000001",
+                            Arrays.asList(
+                                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                            )),
+                    new AccessTuple("0x0000000000000000000000000000000000000002",
+                            Arrays.asList(
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            )),
+                    new AccessTuple("0x0000000000000000000000000000000000000003",
+                            Arrays.asList(
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            ))
+            ));
+            SignatureData signatureData = new SignatureData(
+                    Numeric.hexStringToByteArray("0x01"),
+                    Numeric.hexStringToByteArray("0x5d6d9bc7bb01b05db25f5f2e4a995a4970124387293694f0fd8bdda95bc6e7f4"),
+                    Numeric.hexStringToByteArray("0x782feaf0460341b320710ef7a4f07167d551fd897775af5ec2f1dea095e99cb")
+            );
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(null)
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setAccessList(accessList)
+            );
+
+            // rlpEncoded is a rlp encoded EthereumAccessList transaction containing signatureData defined above.
+            String rlpEncoded = "0x7801f9013d01040a8301e241808080f8eef7940000000000000000000000000000000000000001e1a00000000000000000000000000000000000000000000000000000000000000000f859940000000000000000000000000000000000000002f842a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681f859940000000000000000000000000000000000000003f842a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f098368101a05d6d9bc7bb01b05db25f5f2e4a995a4970124387293694f0fd8bdda95bc6e7f4a00782feaf0460341b320710ef7a4f07167d551fd897775af5ec2f1dea095e99cb";
+            List<String> rlpList = new ArrayList<>();
+            rlpList.add(rlpEncoded);
+            String combined = ethereumAccessList.combineSignedRawTransactions(rlpList);
+
+            assertEquals(rlpEncoded, combined);
+        }
+
+        @Test
+        public void combineSignature_EmptySig() {
+            String gas = "0x1e241";
+            String gasPrice = "0x0a";
+            String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+            String chainID = "0x1";
+            String input = "0x616263646566";
+            String value = "0x0";
+            String nonce = "0x4";
+            AccessList accessList = new AccessList(Arrays.asList(
+                    new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                            Arrays.asList(
+                                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            ))
+            ));
+            SignatureData signatureData = new SignatureData(
+                    Numeric.hexStringToByteArray("0x01"),
+                    Numeric.hexStringToByteArray("0x19676433856a1bd3650e22c210e20c7efdedf1d4f555f1ab6eb7845024f52d99"),
+                    Numeric.hexStringToByteArray("0x70feddce085399eb085b55254fbc8bb5bf912464316b20c3be39bca9015da235")
+            );
+
+            SignatureData emptySig = SignatureData.getEmptySignature();
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(null)
+                            .setTo(to)
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setAccessList(accessList)
+                            .setSignatures(emptySig)
+            );
+
+            // rlpEncoded is a rlp encoded EthereumAccessList transaction containing signatureData defined above.
+            String rlpEncoded = "0x7801f8df01040a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d878080f87cf87a94284e47e6130523b2507ba38cea17dd40a20a0cd0f863a00000000000000000000000000000000000000000000000000000000000000000a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f098368101a019676433856a1bd3650e22c210e20c7efdedf1d4f555f1ab6eb7845024f52d99a070feddce085399eb085b55254fbc8bb5bf912464316b20c3be39bca9015da235";
+
+            List<String> rlpList = new ArrayList<>();
+            rlpList.add(rlpEncoded);
+            String combined = ethereumAccessList.combineSignedRawTransactions(rlpList);
+
+            assertEquals(rlpEncoded, combined);
+        }
+
+        @Test
+        public void throwException_existSignature() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Signatures already defined." + TransactionType.TxTypeEthereumAccessList.toString() + " cannot include more than one signature.");
+
+            String gas = "0x1e241";
+            String gasPrice = "0x0a";
+            String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+            String chainID = "0x1";
+            String input = "0x616263646566";
+            String value = "0x0";
+            String nonce = "0x4";
+            AccessList accessList = new AccessList(Arrays.asList(
+                    new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                            Arrays.asList(
+                                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            ))
+            ));
+            SignatureData signatureData = new SignatureData(
+                    Numeric.hexStringToByteArray("0x01"),
+                    Numeric.hexStringToByteArray("0x19676433856a1bd3650e22c210e20c7efdedf1d4f555f1ab6eb7845024f52d99"),
+                    Numeric.hexStringToByteArray("0x70feddce085399eb085b55254fbc8bb5bf912464316b20c3be39bca9015da235")
+            );
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setFrom(null)
+                            .setTo(to)
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setAccessList(accessList)
+                            .setSignatures(new SignatureData(
+                                    Numeric.hexStringToByteArray("0x1"),
+                                    Numeric.hexStringToByteArray("0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e"),
+                                    Numeric.hexStringToByteArray("0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e")
+                            ))
+            );
+
+            // rlpEncoded is a rlp encoded EthereumAccessList transaction containing signatureData defined above.
+            String rlpEncoded = "0x7801f8df01040a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d878080f87cf87a94284e47e6130523b2507ba38cea17dd40a20a0cd0f863a00000000000000000000000000000000000000000000000000000000000000000a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f098368101a019676433856a1bd3650e22c210e20c7efdedf1d4f555f1ab6eb7845024f52d99a070feddce085399eb085b55254fbc8bb5bf912464316b20c3be39bca9015da235";
+
+            List<String> rlpList = new ArrayList<>();
+            rlpList.add(rlpEncoded);
+
+            ethereumAccessList.combineSignedRawTransactions(rlpList);
+        }
+
+        @Test
+        public void throwException_differentField() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Transactions containing different information cannot be combined.");
+
+            String gas = "0x1e241";
+            String gasPrice = "0x0a";
+            String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+            String chainID = "0x1";
+            String input = "0x616263646566";
+            String value = "0x0";
+            String nonce = "0x4";
+            AccessList accessList = new AccessList(Arrays.asList(
+                    new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                            Arrays.asList(
+                                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                                    "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                            ))
+            ));
+            // rlpEncoded is a rlp encoded string of EthereumAccessList transaction containing above fields.
+            String rlpEncoded = "0x7801f8df01040a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d878080f87cf87a94284e47e6130523b2507ba38cea17dd40a20a0cd0f863a00000000000000000000000000000000000000000000000000000000000000000a06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc01a019676433856a1bd3650e22c210e20c7efdedf1d4f555f1ab6eb7845024f52d99a070feddce085399eb085b55254fbc8bb5bf912464316b20c3be39bca9015da235";
+
+            // All fields are same with above rlpEncoded EthereumAccessList transaction except accessList field.
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setAccessList(new AccessList(Arrays.asList(
+                                    new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                                            Arrays.asList(
+                                                    "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                                            ))
+                            )))
+                            .setTo(to)
+            );
+
+
+            List<String> rlpList = new ArrayList<>();
+            rlpList.add(rlpEncoded);
+
+            ethereumAccessList.combineSignedRawTransactions(rlpList);
+        }
+    }
+
+    public static class appendSignaturesTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+        static String to = "0x8723590d5D60e35f7cE0Db5C09D3938b26fF80Ae";
+        static BigInteger value = BigInteger.ONE;
+        static BigInteger gas = BigInteger.valueOf(90000);
+        static String gasPrice = "0x19";
+        static String nonce = "0x3a";
+        static BigInteger chainID = BigInteger.valueOf(2019);
+        AccessList accessList = new AccessList(
+                Arrays.asList(
+                        new AccessTuple(
+                                "0x2c8ad0ea2e0781db8b8c9242e07de3a5beabb71a",
+                                Arrays.asList(
+                                        "0x4f42391603e79b2a90c3fbfc070c995eb1163e0ac00fb4e8f3da2dc81c451b98",
+                                        "0xc4a32abdf1905059fdfc304aae1e8924279a36b2a6428552237f590156ed7717"
+                                )
+                        ))
+        );
+
+        static SignatureData signatureData = new SignatureData(
+                Numeric.hexStringToByteArray("0x1"),
+                Numeric.hexStringToByteArray("0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e"),
+                Numeric.hexStringToByteArray("0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e")
+        );
+
+        @Test
+        public void appendSignature() {
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+
+            ethereumAccessList.appendSignatures(signatureData);
+
+            assertEquals(signatureData, ethereumAccessList.getSignatures().get(0));
+        }
+
+        @Test
+        public void throwException_invalidParity() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Invalid signature: The y-parity of the transaction should either be 0 or 1.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+
+            ethereumAccessList.appendSignatures(new SignatureData(
+                    Numeric.hexStringToByteArray("0x25"),
+                    Numeric.hexStringToByteArray("0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e"),
+                    Numeric.hexStringToByteArray("0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e")
+            ));
+        }
+
+
+        @Test
+        public void throwException_setSignature_invalidParity() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Invalid signature: The y-parity of the transaction should either be 0 or 1.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setValue(value)
+                            .setAccessList(accessList)
+                            .setSignatures(new SignatureData(
+                                    Numeric.hexStringToByteArray("0x25"),
+                                    Numeric.hexStringToByteArray("0xade9480f584fe481bf070ab758ecc010afa15debc33e1bd75af637d834073a6e"),
+                                    Numeric.hexStringToByteArray("0x38160105d78cef4529d765941ad6637d8dcf6bd99310e165fee1c39fff2aa27e")
+                            ))
+            );
+        }
+
+
+        @Test
+        public void appendSignatureWithEmptySig() {
+            SignatureData emptySignature = SignatureData.getEmptySignature();
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setValue(value)
+                            .setAccessList(accessList)
+                            .setSignatures(emptySignature)
+            );
+
+            ethereumAccessList.appendSignatures(signatureData);
+
+            assertEquals(signatureData, ethereumAccessList.getSignatures().get(0));
+        }
+
+        @Test
+        public void appendSignatureList() {
+            List<SignatureData> list = new ArrayList<>();
+            list.add(signatureData);
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setAccessList(accessList)
+                            .setTo(to)
+            );
+
+            ethereumAccessList.appendSignatures(list);
+
+            assertEquals(signatureData, ethereumAccessList.getSignatures().get(0));
+        }
+
+        @Test
+        public void appendSignatureList_EmptySig() {
+            List<SignatureData> list = new ArrayList<>();
+            list.add(signatureData);
+
+            SignatureData emptySignature = SignatureData.getEmptySignature();
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(emptySignature)
+            );
+
+            ethereumAccessList.appendSignatures(list);
+
+            assertEquals(signatureData, ethereumAccessList.getSignatures().get(0));
+        }
+
+        @Test
+        public void throwException_appendData_existsSignatureInTransaction() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Signatures already defined." + TransactionType.TxTypeEthereumAccessList.toString() + " cannot include more than one signature.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(signatureData)
+            );
+
+            ethereumAccessList.appendSignatures(signatureData);
+        }
+
+        @Test
+        public void throwException_appendList_existsSignatureInTransaction() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Signatures already defined." + TransactionType.TxTypeEthereumAccessList.toString() + " cannot include more than one signature.");
+
+            List<SignatureData> list = new ArrayList<>();
+            list.add(signatureData);
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setSignatures(list)
+            );
+
+            ethereumAccessList.appendSignatures(list);
+        }
+
+        @Test
+        public void throwException_tooLongSignatures() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("Signatures are too long " + TransactionType.TxTypeEthereumAccessList.toString() + " cannot include more than one signature.");
+
+            List<SignatureData> list = new ArrayList<>();
+            list.add(signatureData);
+            list.add(signatureData);
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setTo(to)
+                            .setAccessList(accessList)
+                            .setValue(value)
+            );
+
+            ethereumAccessList.appendSignatures(list);
+        }
+    }
+
+    public static class getRLPEncodingForSignatureTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver(Caver.DEFAULT_URL);
+        static String gas = "0x1e241";
+        static String gasPrice = "0x0a";
+        static String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+        static String chainID = "0x1";
+        static String input = "0x616263646566";
+        static String value = "0x0";
+        static String nonce = "0x4";
+
+        static AccessList accessList = new AccessList(Arrays.asList(
+                new AccessTuple("0x0000000000000000000000000000000000000001",
+                        Arrays.asList(
+                                "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        )),
+                new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                        Arrays.asList(
+                                "0xd2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761",
+                                "0xd2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7c"
+                        )),
+                new AccessTuple("0x0000000000000000000000000000000000000003",
+                        Arrays.asList(
+                                "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681",
+                                "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc"
+                        ))
+        ));
+
+        @Test
+        public void getRLPEncodingForSignature() {
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+            );
+
+            String expected = "0x01f9011401040a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d878086616263646566f8eef7940000000000000000000000000000000000000001e1a00000000000000000000000000000000000000000000000000000000000000000f85994284e47e6130523b2507ba38cea17dd40a20a0cd0f842a0d2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7ca0d2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761f859940000000000000000000000000000000000000003f842a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681";
+            String rlpEncodedSign = ethereumAccessList.getRLPEncodingForSignature();
+
+            assertEquals(expected, rlpEncodedSign);
+        }
+
+        @Test
+        public void throwException_NotDefined_Nonce() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+            );
+
+            String encoded = ethereumAccessList.getRLPEncodingForSignature();
+        }
+
+        @Test
+        public void throwException_NotDefined_GasPrice() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+            );
+            String encoded = ethereumAccessList.getRLPEncodingForSignature();
+
+        }
+
+        @Test
+        public void throwException_NotDefined_ChainID() {
+            expectedException.expect(RuntimeException.class);
+            expectedException.expectMessage("chainId is undefined. Define chainId in transaction or use 'transaction.fillTransaction' to fill values.");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setValue(value)
+                            .setInput(input)
+                            .setTo(to)
+                            .setAccessList(accessList)
+            );
+            String encoded = ethereumAccessList.getRLPEncodingForSignature();
+        }
+    }
+
+    public static class signWithKeyTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver();
+
+        static AbstractKeyring coupledKeyring;
+        static AbstractKeyring deCoupledKeyring;
+        static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";
+
+        static String gas = "0x1e241";
+        static String gasPrice = "0x0a";
+        static String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+        static String chainID = "0x1";
+        static String input = "0x616263646566";
+        static String value = "0x1";
+        static String nonce = "0x4";
+
+        static AccessList accessList = new AccessList(Arrays.asList(
+                new AccessTuple("0x0000000000000000000000000000000000000001",
+                        Arrays.asList(
+                                "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        )),
+                new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                        Arrays.asList(
+                                "0xd2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7c",
+                                "0xd2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761"
+                        )),
+                new AccessTuple("0x0000000000000000000000000000000000000003",
+                        Arrays.asList(
+                                "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc",
+                                "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681"
+                        ))
+        ));
+
+        public static EthereumAccessList createEthereumAccessList() {
+            return caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setTo(to)
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setInput(input)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+        }
+
+        static SignatureData expectedSignature = new SignatureData(
+                "0x01",
+                "0xbf84d5909e08e2e2bb1d5fa975fc2886fa0306c3279f1ad44ade0b8c5c094e7f",
+                "64bb96aea6a5b42fc0ef65365b7eb2b347de4e9a58167975307173b7bd52a4a8"
+        );
+        static String expectedRlpEncoded = "0x7801f9015701040a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d870186616263646566f8eef7940000000000000000000000000000000000000001e1a00000000000000000000000000000000000000000000000000000000000000000f85994284e47e6130523b2507ba38cea17dd40a20a0cd0f842a0d2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7ca0d2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761f859940000000000000000000000000000000000000003f842a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f098368101a0bf84d5909e08e2e2bb1d5fa975fc2886fa0306c3279f1ad44ade0b8c5c094e7fa064bb96aea6a5b42fc0ef65365b7eb2b347de4e9a58167975307173b7bd52a4a8";
+
+
+        @BeforeClass
+        public static void preSetup() {
+            coupledKeyring = caver.wallet.keyring.createFromPrivateKey(privateKey);
+            deCoupledKeyring = caver.wallet.keyring.createWithSingleKey(
+                    caver.wallet.keyring.generate().getAddress(),
+                    privateKey
+            );
+        }
+
+        @Test
+        public void signWithKey_Keyring() throws IOException {
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            AbstractTransaction tx = ethereumAccessList.sign(coupledKeyring, 0, TransactionHasher::getHashForSignature);
+            Assert.assertEquals(expectedSignature, tx.getSignatures().get(0));
+            Assert.assertEquals(expectedRlpEncoded, tx.getRawTransaction());
+        }
+
+        @Test
+        public void signWithKey_Keyring_NoIndex() throws IOException {
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            AbstractTransaction tx = ethereumAccessList.sign(coupledKeyring, TransactionHasher::getHashForSignature);
+            Assert.assertEquals(expectedSignature, tx.getSignatures().get(0));
+            Assert.assertEquals(expectedRlpEncoded, tx.getRawTransaction());
+        }
+
+        @Test
+        public void signWithKey_Keyring_NoSigner() throws IOException {
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            AbstractTransaction tx = ethereumAccessList.sign(coupledKeyring, 0);
+            Assert.assertEquals(expectedSignature, tx.getSignatures().get(0));
+            Assert.assertEquals(expectedRlpEncoded, tx.getRawTransaction());
+        }
+
+        @Test
+        public void signWithKey_Keyring_Only() throws IOException {
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            AbstractTransaction tx = ethereumAccessList.sign(coupledKeyring);
+            Assert.assertEquals(expectedSignature, tx.getSignatures().get(0));
+            Assert.assertEquals(expectedRlpEncoded, tx.getRawTransaction());
+        }
+
+        @Test
+        public void signWithKey_KeyString_NoIndex() throws IOException {
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            AbstractTransaction tx = ethereumAccessList.sign(privateKey, TransactionHasher::getHashForSignature);
+            Assert.assertEquals(expectedSignature, tx.getSignatures().get(0));
+            Assert.assertEquals(expectedRlpEncoded, tx.getRawTransaction());
+        }
+
+        @Test
+        public void throwException_decoupledKey() throws IOException {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("TxTypeEthereumAccessList cannot be signed with a decoupled keyring.");
+
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            ethereumAccessList.sign(deCoupledKeyring);
+        }
+
+        @Test
+        public void throwException_notEqualAddress() throws IOException {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("The from address of the transaction is different with the address of the keyring to use");
+
+            EthereumAccessList ethereumAccessList = caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setNonce(nonce)
+                            .setGas(Numeric.toBigInt(gas))
+                            .setGasPrice(Numeric.toBigInt(gasPrice))
+                            .setChainId(Numeric.toBigInt(chainID))
+                            .setInput(input)
+                            .setValue(Numeric.toBigInt(value))
+                            .setFrom("0x7b65b75d204abed71587c9e519a89277766aaaa1")
+                            .setTo(to)
+                            .setAccessList(accessList)
+            );
+
+            ethereumAccessList.sign(coupledKeyring);
+        }
+    }
+
+    public static class signWithKeysTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        static Caver caver = new Caver();
+
+        static AbstractKeyring coupledKeyring;
+        static AbstractKeyring deCoupledKeyring;
+        static String privateKey = "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8";
+
+        static String gas = "0x1e241";
+        static String gasPrice = "0x0a";
+        static String to = "0x095e7baea6a6c7c4c2dfeb977efac326af552d87";
+        static String chainID = "0x1";
+        static String input = "0x616263646566";
+        static String value = "0x1";
+        static String nonce = "0x4";
+
+        static AccessList accessList = new AccessList(Arrays.asList(
+                new AccessTuple("0x0000000000000000000000000000000000000001",
+                        Arrays.asList(
+                                "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        )),
+                new AccessTuple("0x284e47e6130523b2507ba38cea17dd40a20a0cd0",
+                        Arrays.asList(
+                                "0xd2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7c",
+                                "0xd2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761"
+                        )),
+                new AccessTuple("0x0000000000000000000000000000000000000003",
+                        Arrays.asList(
+                                "0x46d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fc",
+                                "0x6eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f0983681"
+                        ))
+        ));
+
+        public static EthereumAccessList createEthereumAccessList() {
+            return caver.transaction.ethereumAccessList.create(
+                    TxPropertyBuilder.ethereumAccessList()
+                            .setTo(to)
+                            .setNonce(nonce)
+                            .setGas(gas)
+                            .setGasPrice(gasPrice)
+                            .setInput(input)
+                            .setChainId(chainID)
+                            .setValue(value)
+                            .setAccessList(accessList)
+            );
+        }
+
+        static SignatureData expectedSignature = new SignatureData(
+                "0x01",
+                "0xbf84d5909e08e2e2bb1d5fa975fc2886fa0306c3279f1ad44ade0b8c5c094e7f",
+                "64bb96aea6a5b42fc0ef65365b7eb2b347de4e9a58167975307173b7bd52a4a8"
+        );
+        static String expectedRlpEncoded = "0x7801f9015701040a8301e24194095e7baea6a6c7c4c2dfeb977efac326af552d870186616263646566f8eef7940000000000000000000000000000000000000001e1a00000000000000000000000000000000000000000000000000000000000000000f85994284e47e6130523b2507ba38cea17dd40a20a0cd0f842a0d2b691e13d4c3754fbe5dc75439f25dd11a908d89f5bbc55cd5bc4978f078b7ca0d2db659067b2b322f7010149472b81f172b9e331e1831ebee11c7b73facb0761f859940000000000000000000000000000000000000003f842a046d62a62fb985e2e7691a9044b8fae9149311c7f3dcf669265fe5c96072ba4fca06eab5ba2ea17e1ef4eac404d25f1fe9224421e3b639aec73d3b99c39f098368101a0bf84d5909e08e2e2bb1d5fa975fc2886fa0306c3279f1ad44ade0b8c5c094e7fa064bb96aea6a5b42fc0ef65365b7eb2b347de4e9a58167975307173b7bd52a4a8";
+
+
+        @BeforeClass
+        public static void preSetup() {
+            coupledKeyring = caver.wallet.keyring.createFromPrivateKey(privateKey);
+            deCoupledKeyring = caver.wallet.keyring.createWithSingleKey(
+                    caver.wallet.keyring.generate().getAddress(),
+                    privateKey
+            );
+        }
+
+        @Test
+        public void signWithKeys_KeyString() throws IOException {
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            AbstractTransaction tx = ethereumAccessList.sign(privateKey, TransactionHasher::getHashForSignature);
+            Assert.assertEquals(expectedSignature, tx.getSignatures().get(0));
+            Assert.assertEquals(expectedRlpEncoded, tx.getRawTransaction());
+        }
+
+        @Test
+        public void signWithKeys_KeyString_KlaytnWalletKeyFormat() throws IOException {
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            String klaytnKey = privateKey + "0x00" + caver.wallet.keyring.createFromPrivateKey(privateKey).getAddress();
+            AbstractTransaction tx = ethereumAccessList.sign(klaytnKey, TransactionHasher::getHashForSignature);
+            Assert.assertEquals(expectedSignature, tx.getSignatures().get(0));
+            Assert.assertEquals(expectedRlpEncoded, tx.getRawTransaction());
+        }
+
+        @Test
+        public void throwException_KlaytnWalletKeyFormat_decoupledKey() throws IOException {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage(TransactionType.TxTypeEthereumAccessList + " cannot be signed with a decoupled keyring.");
+
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            String klaytnKey = privateKey + "0x00" + caver.wallet.keyring.generate().getAddress();
+            ethereumAccessList.sign(klaytnKey);
+        }
+
+        @Test
+        public void throwException_multipleKeyring() throws IOException {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage(TransactionType.TxTypeEthereumAccessList + " cannot be signed with a decoupled keyring.");
+
+            String[] privateKeyArr = {
+                    caver.wallet.keyring.generateSingleKey(),
+                    caver.wallet.keyring.generateSingleKey()
+            };
+
+            AbstractKeyring keyring = caver.wallet.keyring.createWithMultipleKey(
+                    caver.wallet.keyring.generate().getAddress(),
+                    privateKeyArr
+            );
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+            ethereumAccessList.sign(keyring);
+        }
+
+        @Test
+        public void throwException_roleBasedKeyring() throws IOException {
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage(TransactionType.TxTypeEthereumAccessList + " cannot be signed with a decoupled keyring.");
+
+            String[][] privateKeyArr = {
+                    {
+                            caver.wallet.keyring.generateSingleKey(),
+                            caver.wallet.keyring.generateSingleKey()
+                    },
+                    {
+                            caver.wallet.keyring.generateSingleKey(),
+                            caver.wallet.keyring.generateSingleKey()
+                    },
+                    {
+                            caver.wallet.keyring.generateSingleKey(),
+                            caver.wallet.keyring.generateSingleKey()
+                    }
+            };
+
+            EthereumAccessList ethereumAccessList = createEthereumAccessList();
+
+            AbstractKeyring keyring = caver.wallet.keyring.createWithRoleBasedKey(
+                    caver.wallet.keyring.generate().getAddress(),
+                    Arrays.asList(privateKeyArr)
+            );
+            ethereumAccessList.sign(keyring);
+        }
+    }
+
+}

--- a/core/src/test/java/com/klaytn/caver/common/transaction/LegacyTransactionTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/LegacyTransactionTest.java
@@ -369,7 +369,7 @@ public class LegacyTransactionTest {
         @Test
         public void throwException_decoupledKey() throws IOException {
             expectedException.expect(IllegalArgumentException.class);
-            expectedException.expectMessage("A legacy transaction cannot be signed with a decoupled keyring.");
+            expectedException.expectMessage("TxTypeLegacyTransaction cannot be signed with a decoupled keyring.");
 
             LegacyTransaction legacyTransaction = createLegacyTransaction();
             legacyTransaction.sign(deCoupledKeyring);
@@ -483,7 +483,7 @@ public class LegacyTransactionTest {
         @Test
         public void throwException_decoupledKey() throws IOException {
             expectedException.expect(IllegalArgumentException.class);
-            expectedException.expectMessage("A legacy transaction cannot be signed with a decoupled keyring.");
+            expectedException.expectMessage("TxTypeLegacyTransaction cannot be signed with a decoupled keyring.");
 
             LegacyTransaction legacyTransaction = createLegacyTransaction();
             legacyTransaction.sign(deCoupledKeyring);
@@ -492,7 +492,7 @@ public class LegacyTransactionTest {
         @Test
         public void throwException_KlaytnWalletKeyFormat_decoupledKey() throws IOException {
             expectedException.expect(IllegalArgumentException.class);
-            expectedException.expectMessage("A legacy transaction cannot be signed with a decoupled keyring.");
+            expectedException.expectMessage("TxTypeLegacyTransaction cannot be signed with a decoupled keyring.");
 
             LegacyTransaction legacyTransaction = createLegacyTransaction();
 
@@ -503,7 +503,7 @@ public class LegacyTransactionTest {
         @Test
         public void throwException_multipleKeyring() throws IOException {
             expectedException.expect(IllegalArgumentException.class);
-            expectedException.expectMessage("A legacy transaction cannot be signed with a decoupled keyring.");
+            expectedException.expectMessage("TxTypeLegacyTransaction cannot be signed with a decoupled keyring.");
 
             String[] privateKeyArr = {
                     caver.wallet.keyring.generateSingleKey(),
@@ -522,7 +522,7 @@ public class LegacyTransactionTest {
         @Test
         public void throwException_roleBasedKeyring() throws IOException {
             expectedException.expect(IllegalArgumentException.class);
-            expectedException.expectMessage("A legacy transaction cannot be signed with a decoupled keyring.");
+            expectedException.expectMessage("TxTypeLegacyTransaction cannot be signed with a decoupled keyring.");
 
             String[][] privateKeyArr = {
                     {

--- a/core/src/test/java/com/klaytn/caver/common/transaction/TransactionHelperTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/TransactionHelperTest.java
@@ -62,7 +62,6 @@ public class TransactionHelperTest {
             assertEquals(expected.getFrom(), actual.getFrom());
             assertEquals(expected.getGas(), actual.getGas());
             assertEquals(expected.getNonce(), actual.getNonce());
-            assertEquals(expected.getGasPrice(), actual.getGasPrice());
             assertEquals(expected.getHash(), actual.getTransactionHash());
         }
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/TransactionHelperTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/TransactionHelperTest.java
@@ -84,6 +84,13 @@ public class TransactionHelperTest {
         }
 
         @Test
+        public void ethereumAccessList() {
+            Transaction.TransactionData txObject = sampleTxData.get("ethereumAccessList");
+            EthereumAccessList ethereumAccessList = (EthereumAccessList)txObject.convertToCaverTransaction(caver.rpc.klay);
+            checkTxObject(txObject, ethereumAccessList);
+        }
+
+        @Test
         public void valueTransfer() {
             Transaction.TransactionData txObject = sampleTxData.get("valueTransfer");
             ValueTransfer valueTransfer = (ValueTransfer)txObject.convertToCaverTransaction(caver.rpc.klay);

--- a/core/src/test/resources/TransactionSample.json
+++ b/core/src/test/resources/TransactionSample.json
@@ -616,5 +616,37 @@
     "transactionIndex":"0x0",
     "type":"TxTypeFeeDelegatedChainDataAnchoringWithRatio",
     "typeInt":74
+  },
+  "ethereumAccessList":{
+    "accessList": [
+      {
+        "address": "0xca7a99380131e6c76cfa622396347107aeedca2d",
+        "storageKeys": [
+          "0x0709c257577296fac29c739dad24e55b70a260497283cf9885ab67b4daa9b67f"
+        ]
+      }
+    ],
+    "blockHash": "0x43459f308ba7e54976491922c062cad07c70798a24de403ee830f2c36f0eb59e",
+    "blockNumber": "0x5b",
+    "chainID": "0x7e3",
+    "from": "0xca7a99380131e6c76cfa622396347107aeedca2d",
+    "gas": "0xf423f",
+    "gasPrice": "0x5d21dba00",
+    "hash": "0x658b0aa2b625a1a0c3c9fe54e7f5f51ba962aeb7e62ae2ed338597058a603d71",
+    "input": "0x",
+    "nonce": "0x0",
+    "senderTxHash": "0x658b0aa2b625a1a0c3c9fe54e7f5f51ba962aeb7e62ae2ed338597058a603d71",
+    "signatures": [
+      {
+        "R": "0x1c064e8434def2a74b129dfaa5bd98e8fb8402fc5db284ecdd6807351681ba75",
+        "S": "0x3515882ee8d0d3a59c3075eca9748695f0a3e9a7f52b7e4987950eef52bbb42",
+        "V": "0x1"
+      }
+    ],
+    "to": "0x8c9f4468ae04fb3d79c80f6eacf0e4e1dd21deee",
+    "transactionIndex": "0x0",
+    "type": "TxTypeEthereumAccessList",
+    "typeInt": 30721,
+    "value": "0x1"
   }
 }


### PR DESCRIPTION
## Proposed changes

* Add setter and getter for gasPrice for each transaction which have gasPrice field.
* Override `combineSignedRawTransaction`
  * Hard to make common usage because now we cannot compare gasPrice field by using Abstract class.
* Override fillTransaction
  * For common fields, use super.fillTransaction.
* Override validateOptionalValues
  * For common fields, use super.validateOptionalValues.

This PR contains #291 changes, so #291 must be merged first.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
