### PR TITLE
Removed gas price from AbstractTransaction

### DIFF
--- a/core/ipfs.txt
+++ b/core/ipfs.txt
@@ -1,0 +1,1 @@
+This is IPFS test.

--- a/core/ipfs.txt
+++ b/core/ipfs.txt
@@ -1,1 +1,0 @@
-This is IPFS test.

--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractFeeDelegatedWithRatioTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractFeeDelegatedWithRatioTransaction.java
@@ -74,15 +74,14 @@ abstract public class AbstractFeeDelegatedWithRatioTransaction extends AbstractF
      * @param from The address of the sender.
      * @param nonce A value used to uniquely identify a sender’s transaction.
      * @param gas The maximum amount of gas the transaction is allowed to use.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
      * @param chainId Network ID
      * @param signatures A signature list
      * @param feePayer The address of the fee payer.
      * @param feePayerSignatures The fee payers's signatures.
      * @param feeRatio A fee ratio of the fee payer.
      */
-    public AbstractFeeDelegatedWithRatioTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio) {
-        super(klaytnCall, type, from, nonce, gas, gasPrice, chainId, signatures, feePayer, feePayerSignatures);
+    public AbstractFeeDelegatedWithRatioTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String chainId, List<SignatureData> signatures, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio) {
+        super(klaytnCall, type, from, nonce, gas, chainId, signatures, feePayer, feePayerSignatures);
         setFeeRatio(feeRatio);
     }
 

--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
@@ -72,11 +72,6 @@ abstract public class AbstractTransaction {
     private String gas;
 
     /**
-     * A unit price of gas in peb the sender will pay for a transaction fee.
-     */
-    private String gasPrice = "0x";
-
-    /**
      * Network ID
      */
     private String chainId = "0x";
@@ -96,7 +91,6 @@ abstract public class AbstractTransaction {
 
         private String from;
         private String nonce = "0x";
-        private String gasPrice = "0x";
         private String chainId = "0x";
         private Klay klaytnCall = null;
         private List<SignatureData> signatures = new ArrayList<>();
@@ -127,16 +121,6 @@ abstract public class AbstractTransaction {
 
         public B setGas(BigInteger gas) {
             setGas(Numeric.toHexStringWithPrefix(gas));
-            return (B) this;
-        }
-
-        public B setGasPrice(String gasPrice) {
-            this.gasPrice = gasPrice;
-            return (B) this;
-        }
-
-        public B setGasPrice(BigInteger gasPrice) {
-            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return (B) this;
         }
 
@@ -180,7 +164,6 @@ abstract public class AbstractTransaction {
                 builder.from,
                 builder.nonce,
                 builder.gas,
-                builder.gasPrice,
                 builder.chainId,
                 builder.signatures
         );
@@ -193,16 +176,14 @@ abstract public class AbstractTransaction {
      * @param from The address of the sender.
      * @param nonce A value used to uniquely identify a sender’s transaction.
      * @param gas The maximum amount of gas the transaction is allowed to use.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
      * @param chainId Network ID
      * @param signatures A Signature list
      */
-    public AbstractTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures) {
+    public AbstractTransaction(Klay klaytnCall, String type, String from, String nonce, String gas, String chainId, List<SignatureData> signatures) {
         setKlaytnCall(klaytnCall);
         setType(type);
         setFrom(from);
         setNonce(nonce);
-        setGasPrice(gasPrice);
         setGas(gas);
         setChainId(chainId);
         setSignatures(signatures);
@@ -360,33 +341,8 @@ abstract public class AbstractTransaction {
      * @param rlpEncoded A List of RLP-encoded transaction strings.
      * @return String
      */
-    public String combineSignedRawTransactions(List<String> rlpEncoded) {
-        boolean fillVariable = false;
+    public abstract String combineSignedRawTransactions(List<String> rlpEncoded);
 
-        // If the signatures are empty, there may be an undefined member variable.
-        // In this case, the empty information is filled with the decoded result.
-        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
-
-        for(String encodedStr : rlpEncoded) {
-            AbstractTransaction txObj = TransactionDecoder.decode(encodedStr);
-
-            if(fillVariable) {
-                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
-                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
-                fillVariable = false;
-            }
-
-            // Signatures can only be combined for the same transaction.
-            // Therefore, compare whether the decoded transaction is the same as this.
-            if(!this.compareTxField(txObj, false)) {
-                throw new RuntimeException("Transactions containing different information cannot be combined.");
-            }
-
-            this.appendSignatures(txObj.getSignatures());
-        }
-
-        return this.getRLPEncoding();
-    }
 
     /**
      * Returns a RawTransaction(RLP-encoded transaction string)
@@ -445,15 +401,10 @@ abstract public class AbstractTransaction {
             if(this.chainId.equals("0x")) {
                 this.chainId = klaytnCall.getChainID().send().getResult();
             }
-
-            if(this.gasPrice.equals("0x")) {
-                this.gasPrice = klaytnCall.getGasPrice().send().getResult();
-            }
-
         }
 
-        if(this.nonce.equals("0x") || this.chainId.equals("0x") || this.gasPrice.equals("0x")) {
-            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId, gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        if(this.nonce.equals("0x") || this.chainId.equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data.(nonce, chainId). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
         }
     }
 
@@ -468,7 +419,6 @@ abstract public class AbstractTransaction {
         if(!this.getFrom().toLowerCase().equals(txObj.getFrom().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getNonce()).equals(Numeric.toBigInt(txObj.getNonce()))) return false;
         if(!Numeric.toBigInt(this.getGas()).equals(Numeric.toBigInt(txObj.getGas()))) return false;
-        if(!Numeric.toBigInt(this.getGasPrice()).equals(Numeric.toBigInt(txObj.getGasPrice()))) return false;
 
         if(checkSig) {
             List<SignatureData> dataList = this.getSignatures();
@@ -491,10 +441,6 @@ abstract public class AbstractTransaction {
     public void validateOptionalValues(boolean checkChainID) {
         if(this.getNonce() == null || this.getNonce().isEmpty() || this.getNonce().equals("0x")) {
             throw new RuntimeException("nonce is undefined. Define nonce in transaction or use 'transaction.fillTransaction' to fill values.");
-        }
-
-        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
-            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
         }
 
         if(checkChainID) {
@@ -613,14 +559,6 @@ abstract public class AbstractTransaction {
     }
 
     /**
-     * Getter function for gas price
-     * @return String
-     */
-    public String getGasPrice() {
-        return gasPrice;
-    }
-
-    /**
      * Getter function for chain id
      * @return String
      */
@@ -708,30 +646,6 @@ abstract public class AbstractTransaction {
      */
     public void setNonce(BigInteger nonce) {
         setNonce(Numeric.toHexStringWithPrefix(nonce));
-    }
-
-    /**
-     * Setter function for gas price.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
-     */
-    public void setGasPrice(String gasPrice) {
-        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
-            gasPrice = "0x";
-        }
-
-        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
-            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
-        }
-
-        this.gasPrice = gasPrice;
-    }
-
-    /**
-     * Setter function for gas price.
-     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
-     */
-    public void setGasPrice(BigInteger gasPrice) {
-        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
@@ -19,11 +19,14 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,10 +44,16 @@ public class AccountUpdate extends AbstractTransaction {
     Account account;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * AccountUpdate Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<AccountUpdate.Builder> {
         Account account;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeAccountUpdate.toString());
@@ -52,6 +61,16 @@ public class AccountUpdate extends AbstractTransaction {
 
         public Builder setAccount(Account account) {
             this.account = account;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -92,6 +111,7 @@ public class AccountUpdate extends AbstractTransaction {
     public AccountUpdate(AccountUpdate.Builder builder) {
         super(builder);
         setAccount(builder.account);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -112,11 +132,43 @@ public class AccountUpdate extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setAccount(account);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -241,8 +293,76 @@ public class AccountUpdate extends AbstractTransaction {
         if(!this.getAccount().getRLPEncodingAccountKey().equals(txObj.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            AccountUpdate txObj = (AccountUpdate) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
@@ -293,7 +293,7 @@ public class AccountUpdate extends AbstractTransaction {
         if(!this.getAccount().getRLPEncodingAccountKey().equals(txObj.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
-        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/AccountUpdate.java
@@ -316,7 +316,7 @@ public class AccountUpdate extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             AccountUpdate txObj = (AccountUpdate) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
@@ -265,7 +265,7 @@ public class Cancel extends AbstractTransaction {
         if(!super.compareTxField(obj, checkSig)) return false;
         if(!(obj instanceof Cancel)) return false;
         Cancel txObj = (Cancel) obj;
-        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
@@ -18,11 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,13 +36,29 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/basic#txtypecancel to see more detail.
  */
 public class Cancel extends AbstractTransaction {
+    /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
 
     /**
      * Cancel Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<Cancel.Builder> {
+        String gasPrice = "0x";
+
         public Builder() {
             super(TransactionType.TxTypeCancel.toString());
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+            return this;
         }
 
         public Cancel build() {
@@ -77,6 +96,7 @@ public class Cancel extends AbstractTransaction {
      */
     public Cancel(Cancel.Builder builder) {
         super(builder);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -90,8 +110,50 @@ public class Cancel extends AbstractTransaction {
      * @param signatures A Signature list
      */
     public Cancel(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures) {
-        super(klaytnCall, TransactionType.TxTypeCancel.toString(), from, nonce, gas, gasPrice, chainId, signatures);
+        super(
+                klaytnCall,
+                TransactionType.TxTypeCancel.toString(),
+                from,
+                nonce,
+                gas,
+                chainId,
+                signatures
+        );
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded Cancel string.
@@ -202,7 +264,76 @@ public class Cancel extends AbstractTransaction {
     public boolean compareTxField(AbstractTransaction obj, boolean checkSig) {
         if(!super.compareTxField(obj, checkSig)) return false;
         if(!(obj instanceof Cancel)) return false;
+        Cancel txObj = (Cancel) obj;
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            Cancel txObj = (Cancel) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/Cancel.java
@@ -288,7 +288,7 @@ public class Cancel extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             Cancel txObj = (Cancel) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
@@ -287,7 +287,7 @@ public class ChainDataAnchoring extends AbstractTransaction {
         ChainDataAnchoring txObj = (ChainDataAnchoring)obj;
 
         if(!this.getInput().equals(txObj.getInput())) return false;
-        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
@@ -310,7 +310,7 @@ public class ChainDataAnchoring extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             ChainDataAnchoring txObj = (ChainDataAnchoring) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ChainDataAnchoring.java
@@ -18,12 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,10 +42,16 @@ public class ChainDataAnchoring extends AbstractTransaction {
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * ChainDataAnchoring Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<ChainDataAnchoring.Builder> {
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeChainDataAnchoring.toString());
@@ -51,6 +59,16 @@ public class ChainDataAnchoring extends AbstractTransaction {
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -91,6 +109,7 @@ public class ChainDataAnchoring extends AbstractTransaction {
     public ChainDataAnchoring(ChainDataAnchoring.Builder builder) {
         super(builder);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -105,9 +124,51 @@ public class ChainDataAnchoring extends AbstractTransaction {
      * @param input Data of the service chain.
      */
     public ChainDataAnchoring(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String input) {
-        super(klaytnCall, TransactionType.TxTypeChainDataAnchoring.toString(), from, nonce, gas, gasPrice, chainId, signatures);
+        super(
+                klaytnCall,
+                TransactionType.TxTypeChainDataAnchoring.toString(),
+                from,
+                nonce,
+                gas,
+                chainId,
+                signatures
+        );
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded ChainDataAnchoring string.
@@ -226,9 +287,78 @@ public class ChainDataAnchoring extends AbstractTransaction {
         ChainDataAnchoring txObj = (ChainDataAnchoring)obj;
 
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            ChainDataAnchoring txObj = (ChainDataAnchoring) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for input

--- a/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.account.AccountKeyRoleBased;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.transaction.TransactionHasher;
 import com.klaytn.caver.transaction.TransactionHelper;
 import com.klaytn.caver.transaction.utils.AccessList;
@@ -63,6 +64,11 @@ public class EthereumAccessList extends AbstractTransaction {
     AccessList accessList;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * EthereumAccessList Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<EthereumAccessList.Builder> {
@@ -70,6 +76,7 @@ public class EthereumAccessList extends AbstractTransaction {
         private String value = "0x0";
         private String input = "0x";
         private AccessList accessList = new AccessList();
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeEthereumAccessList.toString());
@@ -97,6 +104,16 @@ public class EthereumAccessList extends AbstractTransaction {
 
         public Builder setAccessList(AccessList accessList) {
             this.accessList = accessList;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -148,6 +165,7 @@ public class EthereumAccessList extends AbstractTransaction {
         setValue(builder.value);
         setInput(builder.input);
         setAccessList(builder.accessList);
+        setGasPrice(builder.gasPrice);
     }
 
 
@@ -172,7 +190,6 @@ public class EthereumAccessList extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
@@ -180,7 +197,41 @@ public class EthereumAccessList extends AbstractTransaction {
         setValue(value);
         setInput(input);
         setAccessList(accessList);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     @Override
     public String getRLPEncoding() {
@@ -256,10 +307,77 @@ public class EthereumAccessList extends AbstractTransaction {
         if (!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if (!this.getInput().equals(txObj.getInput())) return false;
         if (!this.getAccessList().equals(txObj.getAccessList())) return false;
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
 
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            EthereumAccessList txObj = (EthereumAccessList) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
 
     /**
      * Decodes a RLP-encoded EthereumAccessList string.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
@@ -330,7 +330,7 @@ public class EthereumAccessList extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             EthereumAccessList txObj = (EthereumAccessList) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/EthereumAccessList.java
@@ -307,7 +307,7 @@ public class EthereumAccessList extends AbstractTransaction {
         if (!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if (!this.getInput().equals(txObj.getInput())) return false;
         if (!this.getAccessList().equals(txObj.getAccessList())) return false;
-        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
@@ -363,7 +363,7 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedAccountUpdate txObj = (FeeDelegatedAccountUpdate) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
@@ -19,12 +19,16 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,10 +46,16 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
     Account account;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedAccountUpdate Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedAccountUpdate.Builder> {
         Account account;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedAccountUpdate.toString());
@@ -53,6 +63,16 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
 
         public Builder setAccount(Account account) {
             this.account = account;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -95,6 +115,7 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
     public FeeDelegatedAccountUpdate(FeeDelegatedAccountUpdate.Builder builder) {
         super(builder);
         setAccount(builder.account);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -117,13 +138,45 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
                 feePayerSignatures
         );
         setAccount(account);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -293,9 +346,78 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
         if(!this.getAccount().getRLPEncodingAccountKey().equals(feeDelegatedAccountUpdate.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
+        if (!this.getGasPrice().equals(feeDelegatedAccountUpdate.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedAccountUpdate txObj = (FeeDelegatedAccountUpdate) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for Account

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdate.java
@@ -346,7 +346,7 @@ public class FeeDelegatedAccountUpdate extends AbstractFeeDelegatedTransaction {
         if(!this.getAccount().getRLPEncodingAccountKey().equals(feeDelegatedAccountUpdate.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
-        if (!this.getGasPrice().equals(feeDelegatedAccountUpdate.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedAccountUpdate.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
@@ -378,7 +378,7 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedAccountUpdateWithRatio txObj = (FeeDelegatedAccountUpdateWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
@@ -18,13 +18,17 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,10 +46,16 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
     Account account;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedAccountUpdateWithRatio Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedAccountUpdateWithRatio.Builder> {
         Account account;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedAccountUpdateWithRatio.toString());
@@ -53,6 +63,16 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
 
         public Builder setAccount(Account account) {
             this.account = account;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -96,6 +116,7 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
     public FeeDelegatedAccountUpdateWithRatio(Builder builder) {
         super(builder);
         setAccount(builder.account);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -119,7 +140,6 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -127,7 +147,41 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
                 feeRatio
         );
         setAccount(account);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedAccountUpdateWithRatio string.
@@ -300,9 +354,85 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
         if(!this.getAccount().getRLPEncodingAccountKey().equals(feeDelegatedAccountUpdate.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
+        if (!this.getGasPrice().equals(feeDelegatedAccountUpdate.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedAccountUpdateWithRatio txObj = (FeeDelegatedAccountUpdateWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for Account

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedAccountUpdateWithRatio.java
@@ -354,7 +354,7 @@ public class FeeDelegatedAccountUpdateWithRatio extends AbstractFeeDelegatedWith
         if(!this.getAccount().getRLPEncodingAccountKey().equals(feeDelegatedAccountUpdate.getAccount().getRLPEncodingAccountKey())) {
             return false;
         }
-        if (!this.getGasPrice().equals(feeDelegatedAccountUpdate.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedAccountUpdate.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
@@ -19,12 +19,15 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.account.Account;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,13 +38,29 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/fee-delegation#txtypefeedelegatedcancel to see more detail.
  */
 public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
+    /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
 
     /**
      * FeeDelegatedCancel Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedCancel.Builder> {
+        String gasPrice = "0x";
+
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedCancel.toString());
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+            return this;
         }
 
         public FeeDelegatedCancel build() {
@@ -81,6 +100,7 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
      */
     public FeeDelegatedCancel(FeeDelegatedCancel.Builder builder) {
         super(builder);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -102,12 +122,44 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
                 feePayerSignatures
         );
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -261,7 +313,85 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
     public boolean compareTxField(AbstractFeeDelegatedTransaction txObj, boolean checkSig) {
         if(!super.compareTxField(txObj, checkSig)) return false;
         if(!(txObj instanceof FeeDelegatedCancel)) return false;
+        FeeDelegatedCancel feeDelegatedCancel = (FeeDelegatedCancel) txObj;
+        if (!this.getGasPrice().equals(feeDelegatedCancel.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedCancel txObj = (FeeDelegatedCancel) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
+
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
@@ -338,7 +338,7 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedCancel txObj = (FeeDelegatedCancel) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancel.java
@@ -314,7 +314,7 @@ public class FeeDelegatedCancel extends AbstractFeeDelegatedTransaction {
         if(!super.compareTxField(txObj, checkSig)) return false;
         if(!(txObj instanceof FeeDelegatedCancel)) return false;
         FeeDelegatedCancel feeDelegatedCancel = (FeeDelegatedCancel) txObj;
-        if (!this.getGasPrice().equals(feeDelegatedCancel.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedCancel.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
@@ -323,7 +323,7 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
         if(!super.compareTxField(txObj, checkSig)) return false;
         if(!(txObj instanceof FeeDelegatedCancelWithRatio)) return false;
         FeeDelegatedCancelWithRatio feeDelegatedCancelWithRatio = (FeeDelegatedCancelWithRatio) txObj;
-        if (!this.getGasPrice().equals(feeDelegatedCancelWithRatio.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedCancelWithRatio.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
@@ -340,7 +340,7 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedCancelWithRatio txObj = (FeeDelegatedCancelWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedCancelWithRatio.java
@@ -17,13 +17,17 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
+import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,13 +38,29 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedcancelwithratio to see more detail.
  */
 public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTransaction {
+    /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
 
     /**
      * FeeDelegatedCancelWithRatio Builder class.
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedCancelWithRatio.Builder> {
+        String gasPrice = "0x";
+
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedCancelWithRatio.toString());
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+            return this;
         }
 
         public FeeDelegatedCancelWithRatio build() {
@@ -81,6 +101,7 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
      */
     public FeeDelegatedCancelWithRatio(Builder builder) {
         super(builder);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -97,7 +118,51 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
      * @param feeRatio A fee ratio of the fee payer.
      */
     public FeeDelegatedCancelWithRatio(Klay klaytnCall, String from, String nonce, String gas, String gasPrice, String chainId, List<SignatureData> signatures, String feePayer, List<SignatureData> feePayerSignatures, String feeRatio) {
-        super(klaytnCall, TransactionType.TxTypeFeeDelegatedCancelWithRatio.toString(), from, nonce, gas, gasPrice, chainId, signatures, feePayer, feePayerSignatures, feeRatio);
+        super(
+                klaytnCall,
+                TransactionType.TxTypeFeeDelegatedCancelWithRatio.toString(),
+                from,
+                nonce,
+                gas,
+                chainId,
+                signatures,
+                feePayer,
+                feePayerSignatures,
+                feeRatio
+        );
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -257,7 +322,78 @@ public class FeeDelegatedCancelWithRatio extends AbstractFeeDelegatedWithRatioTr
     public boolean compareTxField(AbstractFeeDelegatedWithRatioTransaction txObj, boolean checkSig) {
         if(!super.compareTxField(txObj, checkSig)) return false;
         if(!(txObj instanceof FeeDelegatedCancelWithRatio)) return false;
+        FeeDelegatedCancelWithRatio feeDelegatedCancelWithRatio = (FeeDelegatedCancelWithRatio) txObj;
+        if (!this.getGasPrice().equals(feeDelegatedCancelWithRatio.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedCancelWithRatio txObj = (FeeDelegatedCancelWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
+
 }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
@@ -361,7 +361,7 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedChainDataAnchoring txObj = (FeeDelegatedChainDataAnchoring) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,10 +45,16 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedChainDataAnchoring Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedChainDataAnchoring.Builder> {
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedChainDataAnchoring.toString());
@@ -54,6 +62,16 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -96,6 +114,7 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
     public FeeDelegatedChainDataAnchoring(Builder builder) {
         super(builder);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -118,13 +137,45 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
                 feePayerSignatures
         );
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -286,9 +337,85 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
         FeeDelegatedChainDataAnchoring feeDelegatedChainDataAnchoring = (FeeDelegatedChainDataAnchoring)txObj;
 
         if(!this.getInput().equals(feeDelegatedChainDataAnchoring.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedChainDataAnchoring.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedChainDataAnchoring txObj = (FeeDelegatedChainDataAnchoring) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for input

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoring.java
@@ -337,7 +337,7 @@ public class FeeDelegatedChainDataAnchoring extends AbstractFeeDelegatedTransact
         FeeDelegatedChainDataAnchoring feeDelegatedChainDataAnchoring = (FeeDelegatedChainDataAnchoring)txObj;
 
         if(!this.getInput().equals(feeDelegatedChainDataAnchoring.getInput())) return false;
-        if(!this.getGasPrice().equals(feeDelegatedChainDataAnchoring.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedChainDataAnchoring.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
@@ -366,7 +366,7 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedChainDataAnchoringWithRatio txObj = (FeeDelegatedChainDataAnchoringWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,10 +44,16 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedChainDataAnchoringWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedChainDataAnchoringWithRatio.Builder> {
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedChainDataAnchoringWithRatio.toString());
@@ -52,6 +61,16 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -95,6 +114,7 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
     public FeeDelegatedChainDataAnchoringWithRatio(Builder builder) {
         super(builder);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -118,7 +138,6 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -126,6 +145,39 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
                 feeRatio
         );
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -290,9 +342,85 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
         FeeDelegatedChainDataAnchoringWithRatio feeDelegatedChainDataAnchoringWithRatio = (FeeDelegatedChainDataAnchoringWithRatio)txObj;
 
         if(!this.getInput().equals(feeDelegatedChainDataAnchoringWithRatio.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedChainDataAnchoringWithRatio.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedChainDataAnchoringWithRatio txObj = (FeeDelegatedChainDataAnchoringWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for input

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedChainDataAnchoringWithRatio.java
@@ -342,7 +342,7 @@ public class FeeDelegatedChainDataAnchoringWithRatio extends AbstractFeeDelegate
         FeeDelegatedChainDataAnchoringWithRatio feeDelegatedChainDataAnchoringWithRatio = (FeeDelegatedChainDataAnchoringWithRatio)txObj;
 
         if(!this.getInput().equals(feeDelegatedChainDataAnchoringWithRatio.getInput())) return false;
-        if(!this.getGasPrice().equals(feeDelegatedChainDataAnchoringWithRatio.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedChainDataAnchoringWithRatio.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
@@ -433,7 +433,7 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         if(!this.getInput().equals(feeDelegatedSmartContractDeploy.getInput())) return false;
         if(this.getHumanReadable() != feeDelegatedSmartContractDeploy.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(feeDelegatedSmartContractDeploy.getCodeFormat())) return false;
-        if(!this.getGasPrice().equals(feeDelegatedSmartContractDeploy.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedSmartContractDeploy.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
@@ -457,7 +457,7 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractDeploy txObj = (FeeDelegatedSmartContractDeploy) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeploy.java
@@ -18,6 +18,7 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Utils;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +38,6 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/fee-delegation#txtypefeedelegatedsmartcontractdeploy to see more detail.
  */
 public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransaction {
-
     /**
      * The account address that will receive the transferred value.
      */
@@ -65,6 +66,11 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
     String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractDeploy Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedSmartContractDeploy.Builder> {
@@ -73,6 +79,7 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         String input;
         boolean humanReadable = false;
         String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractDeploy.toString());
@@ -110,6 +117,16 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
 
         public Builder setCodeFormat(BigInteger codeFormat) {
             this.codeFormat = Numeric.toHexStringWithPrefix(codeFormat);
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -161,6 +178,7 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         setInput(builder.input);
         setHumanReadable(builder.humanReadable);
         setCodeFormat(builder.codeFormat);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -187,7 +205,6 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -198,6 +215,39 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         setInput(input);
         setHumanReadable(humanReadable);
         setCodeFormat(codeFormat);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -383,9 +433,85 @@ public class FeeDelegatedSmartContractDeploy extends AbstractFeeDelegatedTransac
         if(!this.getInput().equals(feeDelegatedSmartContractDeploy.getInput())) return false;
         if(this.getHumanReadable() != feeDelegatedSmartContractDeploy.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(feeDelegatedSmartContractDeploy.getCodeFormat())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedSmartContractDeploy.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractDeploy txObj = (FeeDelegatedSmartContractDeploy) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
@@ -444,7 +444,7 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         if(!this.getInput().equals(feeDelegatedSmartContractDeployWithRatio.getInput())) return false;
         if(this.getHumanReadable() != feeDelegatedSmartContractDeployWithRatio.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(feeDelegatedSmartContractDeployWithRatio.getCodeFormat())) return false;
-        if(!this.getGasPrice().equals(feeDelegatedSmartContractDeployWithRatio.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedSmartContractDeployWithRatio.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
@@ -468,7 +468,7 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractDeployWithRatio txObj = (FeeDelegatedSmartContractDeployWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractDeployWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Utils;
@@ -26,6 +28,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,6 +68,11 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
     String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractDeployWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedSmartContractDeployWithRatio.Builder> {
@@ -73,6 +81,7 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         String input;
         boolean humanReadable = false;
         String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractDeployWithRatio.toString());
@@ -110,6 +119,16 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
 
         public Builder setCodeFormat(BigInteger codeFormat) {
             this.codeFormat = Numeric.toHexStringWithPrefix(codeFormat);
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -161,6 +180,7 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         setInput(builder.input);
         setHumanReadable(builder.humanReadable);
         setCodeFormat(builder.codeFormat);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -188,7 +208,6 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -200,7 +219,41 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         setInput(input);
         setHumanReadable(humanReadable);
         setCodeFormat(codeFormat);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedSmartContractDeployWithRatio string.
@@ -391,9 +444,85 @@ public class FeeDelegatedSmartContractDeployWithRatio extends AbstractFeeDelegat
         if(!this.getInput().equals(feeDelegatedSmartContractDeployWithRatio.getInput())) return false;
         if(this.getHumanReadable() != feeDelegatedSmartContractDeployWithRatio.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(feeDelegatedSmartContractDeployWithRatio.getCodeFormat())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedSmartContractDeployWithRatio.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractDeployWithRatio txObj = (FeeDelegatedSmartContractDeployWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
@@ -408,7 +408,7 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractExecution txObj = (FeeDelegatedSmartContractExecution) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,12 +54,18 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractExecution Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedSmartContractExecution.Builder> {
         String to;
         String value = "0x00";
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractExecution.toString());
@@ -80,6 +88,16 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -126,6 +144,7 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -150,7 +169,6 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -159,6 +177,39 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -333,8 +384,83 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractExecution txObj = (FeeDelegatedSmartContractExecution) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecution.java
@@ -384,7 +384,7 @@ public class FeeDelegatedSmartContractExecution extends AbstractFeeDelegatedTran
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
-        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
@@ -388,7 +388,7 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         if(!this.getTo().toLowerCase().equals(feeDelegatedSmartContractExecutionWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedSmartContractExecutionWithRatio.getValue()))) return false;
         if(!this.getInput().equals(feeDelegatedSmartContractExecutionWithRatio.getInput())) return false;
-        if(!this.getGasPrice().equals(feeDelegatedSmartContractExecutionWithRatio.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedSmartContractExecutionWithRatio.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
@@ -412,7 +412,7 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedSmartContractExecutionWithRatio txObj = (FeeDelegatedSmartContractExecutionWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedSmartContractExecutionWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,12 +50,18 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedSmartContractExecutionWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedSmartContractExecutionWithRatio.Builder> {
         String to;
         String value = "0x00";
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedSmartContractExecutionWithRatio.toString());
@@ -75,6 +84,16 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -122,6 +141,7 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -147,7 +167,6 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -157,7 +176,41 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedSmartContractExecutionWithRatio string.
@@ -335,8 +388,83 @@ public class FeeDelegatedSmartContractExecutionWithRatio extends AbstractFeeDele
         if(!this.getTo().toLowerCase().equals(feeDelegatedSmartContractExecutionWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedSmartContractExecutionWithRatio.getValue()))) return false;
         if(!this.getInput().equals(feeDelegatedSmartContractExecutionWithRatio.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedSmartContractExecutionWithRatio.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedSmartContractExecutionWithRatio txObj = (FeeDelegatedSmartContractExecutionWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.crypto.KlaySignatureData;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,11 +50,17 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
     String value;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransfer Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedValueTransfer.Builder> {
         String to;
         String value;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransfer.toString());
@@ -70,6 +78,16 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
 
         public Builder setValue(BigInteger value) {
             setValue(Numeric.toHexStringWithPrefix(value));
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -114,6 +132,7 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
         super(builder);
         setTo(builder.to);
         setValue(builder.value);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -137,7 +156,6 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -145,6 +163,39 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
         );
         setTo(to);
         setValue(value);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -315,9 +366,85 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
 
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransfer.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransfer.getValue()))) return false;
+        if(!this.getGasPrice().equals(feeDelegatedValueTransfer.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransfer txObj = (FeeDelegatedValueTransfer) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Setter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
@@ -390,7 +390,7 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransfer txObj = (FeeDelegatedValueTransfer) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransfer.java
@@ -366,7 +366,7 @@ public class FeeDelegatedValueTransfer extends AbstractFeeDelegatedTransaction {
 
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransfer.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransfer.getValue()))) return false;
-        if(!this.getGasPrice().equals(feeDelegatedValueTransfer.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedValueTransfer.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
@@ -410,7 +410,7 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransferMemo txObj = (FeeDelegatedValueTransferMemo) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
@@ -19,6 +19,7 @@ package com.klaytn.caver.transaction.type;
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -26,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +38,6 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/fee-delegation#txtypefeedelegatedvaluetransfermemo to see more detail.
  */
 public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransaction {
-
     /**
      * The account address that will receive the transferred value.
      */
@@ -53,12 +54,18 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransferMemo Builder class
      */
     public static class Builder extends AbstractFeeDelegatedTransaction.Builder<FeeDelegatedValueTransferMemo.Builder> {
         String to;
         String value;
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransferMemo.toString());
@@ -80,6 +87,16 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -126,6 +143,7 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -150,7 +168,6 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -160,7 +177,41 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded FeeDelegatedValueTransferMemo string.
@@ -335,9 +386,85 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransferMemo txObj = (FeeDelegatedValueTransferMemo) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemo.java
@@ -386,7 +386,7 @@ public class FeeDelegatedValueTransferMemo extends AbstractFeeDelegatedTransacti
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
-        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,12 +55,18 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransferMemo Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedValueTransferMemoWithRatio.Builder> {
         String to;
         String value;
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransferMemoWithRatio.toString());
@@ -79,6 +88,16 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -126,6 +145,7 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -151,7 +171,6 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -161,6 +180,39 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -341,8 +393,83 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransferMemoWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransferMemoWithRatio.getValue()))) return false;
         if(!this.getInput().equals(feeDelegatedValueTransferMemoWithRatio.getInput())) return false;
+        if(!this.getGasPrice().equals(feeDelegatedValueTransferMemoWithRatio.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransferMemoWithRatio txObj = (FeeDelegatedValueTransferMemoWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
@@ -393,7 +393,7 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransferMemoWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransferMemoWithRatio.getValue()))) return false;
         if(!this.getInput().equals(feeDelegatedValueTransferMemoWithRatio.getInput())) return false;
-        if(!this.getGasPrice().equals(feeDelegatedValueTransferMemoWithRatio.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedValueTransferMemoWithRatio.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferMemoWithRatio.java
@@ -417,7 +417,7 @@ public class FeeDelegatedValueTransferMemoWithRatio extends AbstractFeeDelegated
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransferMemoWithRatio txObj = (FeeDelegatedValueTransferMemoWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
@@ -373,7 +373,7 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
 
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransferWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransferWithRatio.getValue()))) return false;
-        if(!this.getGasPrice().equals(feeDelegatedValueTransferWithRatio.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(feeDelegatedValueTransferWithRatio.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
@@ -17,7 +17,9 @@
 package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
+import com.klaytn.caver.transaction.AbstractFeeDelegatedTransaction;
 import com.klaytn.caver.transaction.AbstractFeeDelegatedWithRatioTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
@@ -25,6 +27,7 @@ import org.web3j.crypto.Hash;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +39,6 @@ import java.util.List;
  * Please refer to https://docs.klaytn.com/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedvaluetransferwithratio to see more detail.
  */
 public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWithRatioTransaction {
-
     /**
      * The account address that will receive the transferred value.
      */
@@ -48,11 +50,17 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
     String value;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * FeeDelegatedValueTransferWithRatio Builder class
      */
     public static class Builder extends AbstractFeeDelegatedWithRatioTransaction.Builder<FeeDelegatedValueTransferWithRatio.Builder> {
         String to;
         String value;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeFeeDelegatedValueTransferWithRatio.toString());
@@ -70,6 +78,16 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
 
         public Builder setValue(BigInteger value) {
             setValue(Numeric.toHexStringWithPrefix(value));
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -115,6 +133,7 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
         super(builder);
         setTo(builder.to);
         setValue(builder.value);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -139,7 +158,6 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures,
                 feePayer,
@@ -148,6 +166,39 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
         );
         setTo(to);
         setValue(value);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -322,8 +373,83 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
 
         if(!this.getTo().toLowerCase().equals(feeDelegatedValueTransferWithRatio.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(feeDelegatedValueTransferWithRatio.getValue()))) return false;
+        if(!this.getGasPrice().equals(feeDelegatedValueTransferWithRatio.getGasPrice())) return false;
 
         return true;
+    }
+
+    /**
+     * Combines signatures to the transaction from RLP-encoded transaction strings and returns a single transaction with all signatures combined.
+     * When combining the signatures into a transaction instance,
+     * an error is thrown if the decoded transaction contains different value except signatures.
+     * @param rlpEncoded A List of RLP-encoded transaction strings.
+     * @return String
+     */
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        // At initial state of AbstractFeeDelegateTx Object, feePayerSignature field has one empty signature.
+        if((Utils.isEmptySig(this.getFeePayerSignatures())) || Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            FeeDelegatedValueTransferWithRatio txObj = (FeeDelegatedValueTransferWithRatio) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                if(this.getFeePayer().equals("0x") || this.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                    if(!txObj.getFeePayer().equals("0x") && !txObj.getFeePayer().equals(Utils.DEFAULT_ZERO_ADDRESS)) {
+                        this.setFeePayer(txObj.getFeePayer());
+                        fillVariable = false;
+                    }
+                }
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+            this.appendFeePayerSignatures(txObj.getFeePayerSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/FeeDelegatedValueTransferWithRatio.java
@@ -397,7 +397,7 @@ public class FeeDelegatedValueTransferWithRatio extends AbstractFeeDelegatedWith
         for(String encodedStr : rlpEncoded) {
             AbstractFeeDelegatedTransaction decode = (AbstractFeeDelegatedTransaction) TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             FeeDelegatedValueTransferWithRatio txObj = (FeeDelegatedValueTransferWithRatio) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
@@ -351,7 +351,7 @@ public class LegacyTransaction extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
-        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
@@ -18,11 +18,13 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,12 +46,18 @@ public class LegacyTransaction extends AbstractTransaction {
     String value;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * LegacyTransaction Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<LegacyTransaction.Builder> {
         private String to = "0x";
         private String value;
         private String input = "0x";
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeLegacyTransaction.toString());
@@ -72,6 +80,16 @@ public class LegacyTransaction extends AbstractTransaction {
 
         public Builder setTo(String to) {
             this.to = to;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -117,6 +135,7 @@ public class LegacyTransaction extends AbstractTransaction {
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -139,14 +158,47 @@ public class LegacyTransaction extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
     }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
+    }
+
 
     /**
      * Decodes a RLP-encoded LegacyTransaction string.
@@ -299,9 +351,71 @@ public class LegacyTransaction extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            LegacyTransaction txObj = (LegacyTransaction) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/LegacyTransaction.java
@@ -367,7 +367,7 @@ public class LegacyTransaction extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             LegacyTransaction txObj = (LegacyTransaction) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
@@ -396,7 +396,7 @@ public class SmartContractDeploy extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             SmartContractDeploy txObj = (SmartContractDeploy) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
@@ -380,7 +380,7 @@ public class SmartContractDeploy extends AbstractTransaction {
         if(!this.getInput().equals(txObj.getInput())) return false;
         if(this.getHumanReadable() != txObj.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(txObj.getCodeFormat())) return false;
-        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractDeploy.java
@@ -18,6 +18,7 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.CodeFormat;
 import com.klaytn.caver.utils.Utils;
@@ -25,6 +26,7 @@ import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,6 +66,11 @@ public class SmartContractDeploy extends AbstractTransaction {
     String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * SmartContractDeploy Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<SmartContractDeploy.Builder> {
@@ -72,6 +79,7 @@ public class SmartContractDeploy extends AbstractTransaction {
         String input;
         boolean humanReadable = false;
         String codeFormat = Numeric.toHexStringWithPrefix(CodeFormat.EVM);
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeSmartContractDeploy.toString());
@@ -109,6 +117,16 @@ public class SmartContractDeploy extends AbstractTransaction {
 
         public Builder setCodeFormat(BigInteger codeFormat) {
             this.codeFormat = Numeric.toHexStringWithPrefix(codeFormat);
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -158,6 +176,7 @@ public class SmartContractDeploy extends AbstractTransaction {
         setInput(builder.input);
         setHumanReadable(builder.humanReadable);
         setCodeFormat(builder.codeFormat);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -182,7 +201,6 @@ public class SmartContractDeploy extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
@@ -191,6 +209,39 @@ public class SmartContractDeploy extends AbstractTransaction {
         setInput(input);
         setHumanReadable(humanReadable);
         setCodeFormat(codeFormat);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -329,9 +380,71 @@ public class SmartContractDeploy extends AbstractTransaction {
         if(!this.getInput().equals(txObj.getInput())) return false;
         if(this.getHumanReadable() != txObj.getHumanReadable()) return false;
         if(!this.getCodeFormat().equals(txObj.getCodeFormat())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            SmartContractDeploy txObj = (SmartContractDeploy) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to.

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
@@ -348,7 +348,7 @@ public class SmartContractExecution extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             SmartContractExecution txObj = (SmartContractExecution) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
@@ -332,7 +332,7 @@ public class SmartContractExecution extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
-        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/SmartContractExecution.java
@@ -18,12 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,12 +53,18 @@ public class SmartContractExecution extends AbstractTransaction {
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * SmartContractExecution Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<SmartContractExecution.Builder> {
         String to;
         String value = "0x00";
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeSmartContractExecution.toString());
@@ -79,6 +87,16 @@ public class SmartContractExecution extends AbstractTransaction {
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -124,6 +142,7 @@ public class SmartContractExecution extends AbstractTransaction {
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -146,13 +165,45 @@ public class SmartContractExecution extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -281,9 +332,71 @@ public class SmartContractExecution extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if(!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            SmartContractExecution txObj = (SmartContractExecution) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransfer.java
@@ -327,7 +327,7 @@ public class ValueTransfer extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             ValueTransfer txObj = (ValueTransfer) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransfer.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransfer.java
@@ -311,7 +311,7 @@ public class ValueTransfer extends AbstractTransaction {
 
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
-        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
@@ -18,12 +18,14 @@ package com.klaytn.caver.transaction.type;
 
 import com.klaytn.caver.rpc.Klay;
 import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.TransactionDecoder;
 import com.klaytn.caver.utils.BytesUtils;
 import com.klaytn.caver.utils.Utils;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import org.web3j.rlp.*;
 import org.web3j.utils.Numeric;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,12 +53,18 @@ public class ValueTransferMemo extends AbstractTransaction {
     String input;
 
     /**
+     * A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    String gasPrice = "0x";
+
+    /**
      * ValueTransferMemo Builder class
      */
     public static class Builder extends AbstractTransaction.Builder<ValueTransferMemo.Builder> {
         String to;
         String value;
         String input;
+        String gasPrice = "0x";
 
         public Builder() {
             super(TransactionType.TxTypeValueTransferMemo.toString());
@@ -79,6 +87,16 @@ public class ValueTransferMemo extends AbstractTransaction {
 
         public Builder setInput(String input) {
             this.input = input;
+            return this;
+        }
+
+        public Builder setGasPrice(String gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
+        }
+
+        public Builder setGasPrice(BigInteger gasPrice) {
+            setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
             return this;
         }
 
@@ -123,6 +141,7 @@ public class ValueTransferMemo extends AbstractTransaction {
         setTo(builder.to);
         setValue(builder.value);
         setInput(builder.input);
+        setGasPrice(builder.gasPrice);
     }
 
     /**
@@ -145,13 +164,45 @@ public class ValueTransferMemo extends AbstractTransaction {
                 from,
                 nonce,
                 gas,
-                gasPrice,
                 chainId,
                 signatures
         );
         setTo(to);
         setValue(value);
         setInput(input);
+        setGasPrice(gasPrice);
+    }
+
+    /**
+     * Getter function for gas price
+     * @return String
+     */
+    public String getGasPrice() {
+        return gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(String gasPrice) {
+        if(gasPrice == null || gasPrice.isEmpty() || gasPrice.equals("0x")) {
+            gasPrice = "0x";
+        }
+
+        if(!gasPrice.equals("0x") && !Utils.isNumber(gasPrice)) {
+            throw new IllegalArgumentException("Invalid gasPrice. : " + gasPrice);
+        }
+
+        this.gasPrice = gasPrice;
+    }
+
+    /**
+     * Setter function for gas price.
+     * @param gasPrice A unit price of gas in peb the sender will pay for a transaction fee.
+     */
+    public void setGasPrice(BigInteger gasPrice) {
+        setGasPrice(Numeric.toHexStringWithPrefix(gasPrice));
     }
 
     /**
@@ -280,9 +331,71 @@ public class ValueTransferMemo extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
+        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
 
         return true;
     }
+
+    @Override
+    public String combineSignedRawTransactions(List<String> rlpEncoded) {
+        boolean fillVariable = false;
+
+        // If the signatures are empty, there may be an undefined member variable.
+        // In this case, the empty information is filled with the decoded result.
+        if(Utils.isEmptySig(this.getSignatures())) fillVariable = true;
+
+        for(String encodedStr : rlpEncoded) {
+            AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
+            if (!decode.getType().equals(this.getType())) {
+                continue;
+            }
+            ValueTransferMemo txObj = (ValueTransferMemo) decode;
+
+            if(fillVariable) {
+                if(this.getNonce().equals("0x")) this.setNonce(txObj.getNonce());
+                if(this.getGasPrice().equals("0x")) this.setGasPrice(txObj.getGasPrice());
+                fillVariable = false;
+            }
+
+            // Signatures can only be combined for the same transaction.
+            // Therefore, compare whether the decoded transaction is the same as this.
+            if(!this.compareTxField(txObj, false)) {
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
+            }
+
+            this.appendSignatures(txObj.getSignatures());
+        }
+
+        return this.getRLPEncoding();
+    }
+
+    /**
+     * Fills empty optional transaction field.(gasPrice)
+     * @throws IOException
+     */
+    @Override
+    public void fillTransaction() throws IOException {
+        super.fillTransaction();
+        if(this.gasPrice.equals("0x")) {
+            this.setGasPrice(this.getKlaytnCall().getGasPrice().send().getResult());
+        }
+        if(this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("Cannot fill transaction data. (gasPrice). `klaytnCall` must be set in Transaction instance to automatically fill the nonce, chainId or gasPrice. Please call the `setKlaytnCall` to set `klaytnCall` in the Transaction instance.");
+        }
+    }
+
+    /**
+     * Checks that member variables that can be defined by the user are defined.
+     * If there is an undefined variable, an error occurs.
+     */
+    @Override
+    public void validateOptionalValues(boolean checkChainID) {
+        super.validateOptionalValues(checkChainID);
+        if(this.getGasPrice() == null || this.getGasPrice().isEmpty() || this.getGasPrice().equals("0x")) {
+            throw new RuntimeException("gasPrice is undefined. Define gasPrice in transaction or use 'transaction.fillTransaction' to fill values.");
+        }
+    }
+
 
     /**
      * Getter function for to

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
@@ -347,7 +347,7 @@ public class ValueTransferMemo extends AbstractTransaction {
         for(String encodedStr : rlpEncoded) {
             AbstractTransaction decode = TransactionDecoder.decode(encodedStr);
             if (!decode.getType().equals(this.getType())) {
-                continue;
+                throw new RuntimeException("Transactions containing different information cannot be combined.");
             }
             ValueTransferMemo txObj = (ValueTransferMemo) decode;
 

--- a/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/ValueTransferMemo.java
@@ -331,7 +331,7 @@ public class ValueTransferMemo extends AbstractTransaction {
         if(!this.getTo().toLowerCase().equals(txObj.getTo().toLowerCase())) return false;
         if(!Numeric.toBigInt(this.getValue()).equals(Numeric.toBigInt(txObj.getValue()))) return false;
         if(!this.getInput().equals(txObj.getInput())) return false;
-        if (!this.getGasPrice().equals(txObj.getGasPrice())) return false;
+        if(Numeric.toBigInt(this.getGasPrice()).compareTo(Numeric.toBigInt(txObj.getGasPrice())) != 0) return false;
 
         return true;
     }

--- a/core/src/test/java/com/klaytn/caver/common/transaction/TransactionHelperTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/TransactionHelperTest.java
@@ -62,7 +62,6 @@ public class TransactionHelperTest {
             assertEquals(expected.getFrom(), actual.getFrom());
             assertEquals(expected.getGas(), actual.getGas());
             assertEquals(expected.getNonce(), actual.getNonce());
-            assertEquals(expected.getGasPrice(), actual.getGasPrice());
             assertEquals(expected.getHash(), actual.getTransactionHash());
         }
 


### PR DESCRIPTION
## Proposed changes

* Add setter and getter for gasPrice for each transaction which have gasPrice field.
* Override `combineSignedRawTransaction`
  * Hard to make common usage because now we cannot compare gasPrice field by using Abstract class.
* Override fillTransaction
  * For common fields, use super.fillTransaction.
* Override validateOptionalValues
  * For common fields, use super.validateOptionalValues.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
