### PR TITLE
Implemented AbstractTransaction#recoverPublicKeysWithEthereumTypedTransaction()

### DIFF
--- a/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/AbstractTransaction.java
@@ -536,6 +536,11 @@ abstract public class AbstractTransaction {
      */
     public List<String> recoverPublicKeys() {
         try {
+            // If it is EthereumTyped transaction(EthereumAccessList, EthereumDynamicFee), call recoverPublicKeysWithEthereumTypedTransaction.
+            if(TransactionHelper.isEthereumTypedTransaction(this.getType())) {
+                return recoverPublicKeysWithEthereumTypedTransaction();
+            }
+
             if(Utils.isEmptySig(this.getSignatures())) {
                 throw new RuntimeException("Failed to recover public keys from signatures: signatures is empty.");
             }
@@ -562,6 +567,23 @@ abstract public class AbstractTransaction {
         } catch(SignatureException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private List<String> recoverPublicKeysWithEthereumTypedTransaction() throws SignatureException{
+            if(Utils.isEmptySig(this.getSignatures())) {
+                throw new RuntimeException("Failed to recover public keys from signatures: signatures is empty.");
+            }
+
+            String sigHash = TransactionHasher.getHashForSignature(this);
+
+            List<String> publicKeyList = new ArrayList<>();
+            for(SignatureData signatureData : this.getSignatures()) {
+                if(Numeric.toBigInt(signatureData.getV()).compareTo(BigInteger.ZERO) != 0 && Numeric.toBigInt(signatureData.getV()).compareTo(BigInteger.ONE) != 0) {
+                    throw new RuntimeException("Invalid Signature data : the v value must have 0 or 1.");
+                }
+                publicKeyList.add(Utils.recoverPublicKey(sigHash, signatureData, true));
+            }
+            return publicKeyList;
     }
 
     /**

--- a/core/src/main/java/com/klaytn/caver/transaction/TransactionHelper.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/TransactionHelper.java
@@ -22,9 +22,10 @@ import com.klaytn.caver.transaction.type.TransactionType;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 
+import static com.klaytn.caver.transaction.type.TransactionType.TxTypeLegacyTransaction;
 import static com.klaytn.caver.transaction.type.TransactionType.TxTypeEthereumAccessList;
+import static com.klaytn.caver.transaction.type.TransactionType.TxTypeEthereumDynamicFee;
 
 /**
  * This class is a helper class provides methods that handles Transaction object comfortably.
@@ -96,7 +97,7 @@ public class TransactionHelper {
      * @return
      */
     public static boolean isEthereumTransaction(int type) {
-        if (type == TransactionType.TxTypeLegacyTransaction.getType() || type == TxTypeEthereumAccessList.getType()) {
+        if (type == TxTypeLegacyTransaction.getType() || type == TxTypeEthereumAccessList.getType() || type == TxTypeEthereumDynamicFee.getType()) {
             return true;
         }
         return false;
@@ -108,10 +109,21 @@ public class TransactionHelper {
      * @return
      */
     public static boolean isEthereumTransaction(String type) {
-        if (
-                Objects.equals(type, TransactionType.TxTypeLegacyTransaction.toString()) ||
-                        Objects.equals(type, TransactionType.TxTypeEthereumAccessList.toString())
-        ) {
+        if(type.equals(TransactionType.TxTypeLegacyTransaction.toString()) || type.equals(TxTypeEthereumAccessList.toString()) || type.equals(TxTypeEthereumDynamicFee.toString())) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isEthereumTypedTransaction(int type) {
+        if(type == TxTypeEthereumAccessList.getType() || type == TxTypeEthereumDynamicFee.getType()) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isEthereumTypedTransaction(String type) {
+        if(type.equals(TxTypeEthereumAccessList.toString()) || type.equals(TxTypeEthereumDynamicFee.toString())) {
             return true;
         }
         return false;

--- a/core/src/main/java/com/klaytn/caver/transaction/type/TransactionType.java
+++ b/core/src/main/java/com/klaytn/caver/transaction/type/TransactionType.java
@@ -49,7 +49,8 @@ public enum TransactionType {
     TxTypeFeeDelegatedChainDataAnchoring(0x49),
     TxTypeFeeDelegatedChainDataAnchoringWithRatio(0x4a),
 
-    TxTypeEthereumAccessList(0x7801);
+    TxTypeEthereumAccessList(0x7801),
+    TxTypeEthereumDynamicFee(0x7802);
 
     int type;
 

--- a/core/src/test/java/com/klaytn/caver/common/transaction/EthereumAccessListTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/transaction/EthereumAccessListTest.java
@@ -21,6 +21,7 @@ import com.klaytn.caver.transaction.AbstractTransaction;
 import com.klaytn.caver.transaction.TransactionHasher;
 import com.klaytn.caver.transaction.TxPropertyBuilder;
 import com.klaytn.caver.transaction.type.EthereumAccessList;
+import com.klaytn.caver.transaction.type.LegacyTransaction;
 import com.klaytn.caver.transaction.type.TransactionType;
 import com.klaytn.caver.transaction.utils.AccessList;
 import com.klaytn.caver.transaction.utils.AccessTuple;
@@ -1665,6 +1666,47 @@ public class EthereumAccessListTest {
                     Arrays.asList(privateKeyArr)
             );
             ethereumAccessList.sign(keyring);
+        }
+    }
+
+    public static class recoverPublicKeyTest {
+        @Rule
+        public ExpectedException expectedException = ExpectedException.none();
+
+        @Test
+        public void recoverPublicKey() {
+            String expectedPublicKey = "0x3a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d8072e77939dc03ba44790779b7a1025baf3003f6732430e20cd9b76d953391b3";
+            SignatureData signatureData = new SignatureData(
+                    "0x1",
+                    "0xbfc80a874c43b71b67c68fa5927d1443407f31aef4ec6369bbecdb76fc39b0c0",
+                    "0x193e62c1dd63905aee7073958675dcb45d78c716a9a286b54a496e82cb762f26"
+            );
+
+            AccessList accessList = new AccessList(
+                    Arrays.asList(
+                            new AccessTuple(
+                                    "0x0000000000000000000000000000000000000001",
+                                    Arrays.asList(
+                                            "0x0000000000000000000000000000000000000000000000000000000000000000"
+                                    )
+                            ))
+            );
+
+            EthereumAccessList tx = new EthereumAccessList.Builder()
+                    .setFrom("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+                    .setTo("0x7b65b75d204abed71587c9e519a89277766ee1d0")
+                    .setValue("0xa")
+                    .setChainId("0x2")
+                    .setGasPrice("0x19")
+                    .setNonce("0x4d2")
+                    .setGas("0xf4240")
+                    .setInput("0x31323334")
+                    .setAccessList(accessList)
+                    .setSignatures(signatureData)
+                    .build();
+
+            List<String> publicKeys = tx.recoverPublicKeys();
+            assertEquals(expectedPublicKey, publicKeys.get(0));
         }
     }
 

--- a/core/src/test/java/com/klaytn/caver/validator/ValidatorTest.java
+++ b/core/src/test/java/com/klaytn/caver/validator/ValidatorTest.java
@@ -1675,8 +1675,9 @@ public class ValidatorTest {
             spyValidator.validateTransaction(txBuilder.build());
             Mockito.verify(spyValidator).validateSender(any());
 
-            spyValidator.validateTransaction(accessTxBuilder.build());
-            Mockito.verify(spyValidator).validateSender(any());
+            Validator spyValidator1 = Mockito.spy(validator);
+            spyValidator1.validateTransaction(accessTxBuilder.build());
+            Mockito.verify(spyValidator1).validateSender(any());
         }
 
         @Test

--- a/core/src/test/java/com/klaytn/caver/validator/ValidatorTest.java
+++ b/core/src/test/java/com/klaytn/caver/validator/ValidatorTest.java
@@ -22,10 +22,10 @@ import com.klaytn.caver.account.Account;
 import com.klaytn.caver.account.AccountKeyLegacy;
 import com.klaytn.caver.methods.response.AccountKey;
 import com.klaytn.caver.rpc.Klay;
-import com.klaytn.caver.transaction.type.AccountUpdate;
-import com.klaytn.caver.transaction.type.FeeDelegatedValueTransfer;
-import com.klaytn.caver.transaction.type.LegacyTransaction;
-import com.klaytn.caver.transaction.type.ValueTransfer;
+import com.klaytn.caver.transaction.AbstractTransaction;
+import com.klaytn.caver.transaction.type.*;
+import com.klaytn.caver.transaction.utils.AccessList;
+import com.klaytn.caver.transaction.utils.AccessTuple;
 import com.klaytn.caver.wallet.keyring.KeyringFactory;
 import com.klaytn.caver.wallet.keyring.SignatureData;
 import com.klaytn.caver.wallet.keyring.SingleKeyring;
@@ -1570,6 +1570,7 @@ public class ValidatorTest {
     public static class validateTransaction {
         static ValueTransfer.Builder txBuilder;
         static FeeDelegatedValueTransfer.Builder fdTxBuilder;
+        static EthereumAccessList.Builder accessTxBuilder;
         static AccountKey accountKey;
 
         @BeforeClass
@@ -1634,6 +1635,33 @@ public class ValidatorTest {
                                     "0x4fe2a845d92ff48abca3e1d59637fab5f4a4e3172d91772d9bfce60760edc506"
                             )
                     ));
+
+            AccessList accessList = new AccessList(
+                    Arrays.asList(
+                            new AccessTuple(
+                                    "0x0000000000000000000000000000000000000001",
+                                    Arrays.asList(
+                                            "0x0000000000000000000000000000000000000000000000000000000000000000"
+                                    )
+                            ))
+            );
+
+            accessTxBuilder = new EthereumAccessList.Builder()
+                    .setFrom("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+                    .setTo("0x7b65b75d204abed71587c9e519a89277766ee1d0")
+                    .setValue("0xa")
+                    .setChainId("0x2")
+                    .setGasPrice("0x19")
+                    .setNonce("0x4d2")
+                    .setGas("0xf4240")
+                    .setInput("0x31323334")
+                    .setAccessList(accessList)
+                    .setSignatures(new SignatureData(
+                            "0x1",
+                            "0xbfc80a874c43b71b67c68fa5927d1443407f31aef4ec6369bbecdb76fc39b0c0",
+                            "0x193e62c1dd63905aee7073958675dcb45d78c716a9a286b54a496e82cb762f26"
+                    ));
+
         }
 
         @Test
@@ -1645,7 +1673,9 @@ public class ValidatorTest {
 
             Validator spyValidator = Mockito.spy(validator);
             spyValidator.validateTransaction(txBuilder.build());
+            Mockito.verify(spyValidator).validateSender(any());
 
+            spyValidator.validateTransaction(accessTxBuilder.build());
             Mockito.verify(spyValidator).validateSender(any());
         }
 
@@ -1671,6 +1701,7 @@ public class ValidatorTest {
             Validator validator = new Validator(klay);
             assertTrue(validator.validateTransaction(txBuilder.build()));
             assertTrue(validator.validateTransaction(fdTxBuilder.build()));
+            assertTrue(validator.validateTransaction(accessTxBuilder.build()));
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR implemented `recoverPublicKeysWithEthereumTypedTransaction()` in AbstractTransaction.
  - In `tx.RecoverPublicKeys`, it is implemented to branch according to the type of transaction.
  - User can obtain publicKey by executing `tx.RecoverPublicKeys()` in the same way.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
