### PR TITLE
Added KIP-71 Governance parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ lint/tmp/
 # Android Profiling
 *.hprof
 ##
+
+.DS_Store
+ipfs.txt

--- a/core/src/main/java/com/klaytn/caver/methods/response/GovernanceChainConfig.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/GovernanceChainConfig.java
@@ -48,6 +48,30 @@ public class GovernanceChainConfig extends Response<GovernanceChainConfig.ChainC
         private int deriveShaImpl;
 
         /**
+         * The value of istanbulCompatibleBlock field.
+         */
+        @JsonProperty("istanbulCompatibleBlock")
+        private BigInteger istanbulCompatibleBlock;
+
+        /**
+         * The value of londonCompatibleBlock field.
+         */
+        @JsonProperty("londonCompatibleBlock")
+        private BigInteger londonCompatibleBlock;
+
+        /**
+         * The value of ethTxTypeCompatibleBlock field.
+         */
+        @JsonProperty("ethTxTypeCompatibleBlock")
+        private BigInteger ethTxTypeCompatibleBlock;
+
+        /**
+         * The value of kip71CompatibleBlock field.
+         */
+        @JsonProperty("kip71CompatibleBlock")
+        private BigInteger kip71CompatibleBlock;
+
+        /**
          * The value of chainId field.
          */
         @JsonProperty("chainId")
@@ -534,6 +558,39 @@ public class GovernanceChainConfig extends Response<GovernanceChainConfig.ChainC
         public int getChainid() {
             return chainId;
         }
+
+        /**
+         * Getter function for istanbulCompatibleBlock.
+         * @return BigInteger
+         */
+        public BigInteger getIstanbulCompatibleBlock() {
+            return istanbulCompatibleBlock;
+        }
+
+        /**
+         * Getter function for londonCompatibleBlock.
+         * @return BigInteger
+         */
+        public BigInteger getLondonCompatibleBlock() {
+            return londonCompatibleBlock;
+        }
+
+        /**
+         * Getter function for ethTxTypeCompatibleBlock.
+         * @return BigInteger
+         */
+        public BigInteger getEthTxTypeCompatibleBlock() {
+            return ethTxTypeCompatibleBlock;
+        }
+
+        /**
+         * Getter function for kip71CompatibleBlock.
+         * @return BigInteger
+         */
+        public BigInteger getKIP71CompatibleBlock() {
+            return kip71CompatibleBlock;
+        }
+
 
         @Override
         public String toString() {

--- a/core/src/main/java/com/klaytn/caver/methods/response/GovernanceChainConfig.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/GovernanceChainConfig.java
@@ -136,6 +136,12 @@ public class GovernanceChainConfig extends Response<GovernanceChainConfig.ChainC
             private Reward reward;
 
             /**
+             * The value of kip71 field.
+             */
+            @JsonProperty("kip71")
+            private KIP71 kip71;
+
+            /**
              * The value of governingNode field.
              */
             @JsonProperty("governingNode")
@@ -161,6 +167,22 @@ public class GovernanceChainConfig extends Response<GovernanceChainConfig.ChainC
              */
             public void setReward(Reward reward) {
                 this.reward = reward;
+            }
+
+            /**
+             * Getter function for kip71 field.
+             * @return KIP71
+             */
+            public KIP71 getKip71() {
+                return kip71;
+            }
+
+            /**
+             * Setter function for kip71 field.
+             * @param kip71 The value of kip71 field.
+             */
+            public void setKip71(KIP71 kip71) {
+                this.kip71 = kip71;
             }
 
             /**
@@ -355,6 +377,124 @@ public class GovernanceChainConfig extends Response<GovernanceChainConfig.ChainC
              */
             public void setDeferredTxFee(boolean deferredTxFee) {
                 this.deferredTxFee = deferredTxFee;
+            }
+
+            @Override
+            public String toString() {
+                return Utils.printString(this);
+            }
+        }
+
+        public static class KIP71 {
+
+            /**
+             * The value of basefeedenominator field.
+             */
+            @JsonProperty("basefeedenominator")
+            private Integer baseFeeDenominator;
+
+            /**
+             * The value of gastarget field.
+             */
+            @JsonProperty("gastarget")
+            private BigInteger gasTarget;
+
+            /**
+             * The value of lowerboundbasefee field.
+             */
+            @JsonProperty("lowerboundbasefee")
+            private BigInteger lowerBoundBaseFee;
+
+            /**
+             * The value of upperboundbasefee field.
+             */
+            @JsonProperty("upperboundbasefee")
+            private BigInteger upperBoundBaseFee;
+
+            /**
+             * The value of maxblockgasusedforbasefee field.
+             */
+            @JsonProperty("maxblockgasusedforbasefee")
+            private BigInteger maxBlockGasUsedForBaseFee;
+
+            /**
+             * Getter function for baseFeeDenominator.
+             * @return Integer
+             */
+            public Integer getBaseFeeDenominator() {
+                return baseFeeDenominator;
+            }
+
+            /**
+             * Setter function for baseFeeDenominator.
+             * @param baseFeeDenominator The value of baseFeeDenominator
+             */
+            public void setBaseFeeDenominator(Integer baseFeeDenominator) {
+                this.baseFeeDenominator = baseFeeDenominator;
+            }
+
+            /**
+             * Getter function for gasTarget.
+             * @return BigInteger
+             */
+            public BigInteger getGasTarget() {
+                return gasTarget;
+            }
+
+            /**
+             * Setter function for gasTarget.
+             * @param gasTarget The value of gasTarget
+             */
+            public void setGasTarget(BigInteger gasTarget) {
+                this.gasTarget = gasTarget;
+            }
+
+            /**
+             * Getter function for lowerBoundBaseFee.
+             * @return BigInteger
+             */
+            public BigInteger getLowerBoundBaseFee() {
+                return lowerBoundBaseFee;
+            }
+
+            /**
+             * Setter function for lowerBoundBaseFee.
+             * @param lowerBoundBaseFee The value of lowerBoundBaseFee
+             */
+            public void setLowerBoundBaseFee(BigInteger lowerBoundBaseFee) {
+                this.lowerBoundBaseFee = lowerBoundBaseFee;
+            }
+
+            /**
+             * Getter function for upperBoundBaseFee.
+             * @return BigInteger
+             */
+            public BigInteger getUpperBoundBaseFee() {
+                return upperBoundBaseFee;
+            }
+
+            /**
+             * Setter function for upperBoundBaseFee.
+             * @param upperBoundBaseFee The value of upperBoundBaseFee
+             */
+            public void setUpperBoundBaseFee(BigInteger upperBoundBaseFee) {
+                this.upperBoundBaseFee = upperBoundBaseFee;
+            }
+
+            /**
+             * Getter function for maxBlockGasUsedForBaseFee.
+             * @return BigInteger
+             */
+            public BigInteger getMaxBlockGasUsedForBaseFee() {
+                return maxBlockGasUsedForBaseFee;
+            }
+
+            /**
+             * Setter function for maxBlockGasUsedForBaseFee.
+             * @param maxBlockGasUsedForBaseFee The value of maxBlockGasUsedForBaseFee
+             */
+            public void setMaxBlockGasUsedForBaseFee(BigInteger maxBlockGasUsedForBaseFee) {
+                this.maxBlockGasUsedForBaseFee = maxBlockGasUsedForBaseFee;
             }
 
             @Override

--- a/core/src/main/java/com/klaytn/caver/methods/response/GovernanceStakingInfo.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/GovernanceStakingInfo.java
@@ -38,6 +38,7 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
 
         /**
          * The contract address of PoC.
+         * PoC is the previous name of KGF.
          */
         @JsonProperty("PoCAddr")
         private String pocAddr;
@@ -114,6 +115,7 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
 
         /**
          * Getter function for PocAddr.
+         * PoC is the previous name of KGF.
          * @return String
          */
         public String getPocAddr() {
@@ -121,7 +123,16 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
         }
 
         /**
+         * Getter function for KGFAddr.
+         * @return String
+         */
+        public String getKGFAddr() {
+            return pocAddr;
+        }
+
+        /**
          * Setter function for PocAddr.
+         * PoC is the previous name of KGF.
          * @param pocAddr The contract address of PoC.
          */
         public void setPocAddr(String pocAddr) {

--- a/core/src/main/java/com/klaytn/caver/methods/response/IVote.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/IVote.java
@@ -43,7 +43,12 @@ public interface IVote {
         REWARD_USE_DEFERRED_TX_FEE("reward.deferredtxfee", "Boolean"),
         REWARD_MINIMUM_STAKE("reward.minimumstake", "String"),
         REWARD_PROPOSER_UPDATE_INTERVAL("reward.proposerupdateinterval", "BigInteger"),
-        REWARD_STAKING_UPDATE_INTERVAL("reward.stakingupdateinterval", "BigInteger");
+        REWARD_STAKING_UPDATE_INTERVAL("reward.stakingupdateinterval", "BigInteger"),
+        KIP71_LOWER_BOUND_BASE_FEE("kip71.lowerboundbasefee", "BigInteger"),
+        KIP71_UPPER_BOUND_BASE_FEE("kip71.upperboundbasefee", "BigInteger"),
+        KIP71_GAS_TARGET("kip71.gastarget", "BigInteger"),
+        KIP71_MAX_BLOCK_GAS_USED_FOR_BASE_FEE("kip71.maxblockgasusedforbasefee", "BigInteger"),
+        KIP71_BASE_FEE_DENOMINATOR("kip71.basefeedenominator", "Integer");
 
         String key;
         String type;
@@ -894,6 +899,276 @@ public interface IVote {
         }
 
         /**
+         * Get the value of KIP71_LOWER_BOUND_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceItems response = caver.rpc.governance.getItemsAt().send();
+         * Map<String, Object> governanceItem = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71LowerBoundBaseFee(governanceItem);
+         * }</pre>
+         * @param map The map instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71LowerBoundBaseFee(Map<String, Object> map) {
+            return toBigIntegerValue(map.get(KIP71_LOWER_BOUND_BASE_FEE.getKey()));
+        }
+
+        /**
+         * Get the value of KIP71_LOWER_BOUND_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71LowerBoundBaseFee(voteList);
+         * }</pre>
+         * @param list The list instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71LowerBoundBaseFee(List<IVote> list) {
+            for(IVote vote: list) {
+                if(vote.getKey().equals(KIP71_LOWER_BOUND_BASE_FEE.getKey())) {
+                    return toBigIntegerValue(vote.getValue());
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Get the value of KIP71_LOWER_BOUND_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         * GovernanceMyVotes.MyVote myVote = (GovernanceMyVotes.MyVote)voteList.get(0);
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71LowerBoundBaseFee(myVote);
+         * }</pre>
+         * @param vote The instance that implemented IVote to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71LowerBoundBaseFee(IVote vote) {
+            return toBigIntegerValue(vote.getKey(), vote.getValue());
+        }
+
+        /**
+         * Get the value of KIP71_UPPER_BOUND_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceItems response = caver.rpc.governance.getItemsAt().send();
+         * Map<String, Object> governanceItem = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71UpperBoundBaseFee(governanceItem);
+         * }</pre>
+         * @param map The map instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71UpperBoundBaseFee(Map<String, Object> map) {
+            return toBigIntegerValue(map.get(KIP71_UPPER_BOUND_BASE_FEE.getKey()));
+        }
+
+        /**
+         * Get the value of KIP71_UPPER_BOUND_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71UpperBoundBaseFee(voteList);
+         * }</pre>
+         * @param list The list instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71UpperBoundBaseFee(List<IVote> list) {
+            for(IVote vote: list) {
+                if(vote.getKey().equals(KIP71_UPPER_BOUND_BASE_FEE.getKey())) {
+                    return toBigIntegerValue(vote.getValue());
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Get the value of KIP71_UPPER_BOUND_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         * GovernanceMyVotes.MyVote myVote = (GovernanceMyVotes.MyVote)voteList.get(0);
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71UpperBoundBaseFee(myVote);
+         * }</pre>
+         * @param vote The instance that implemented IVote to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71UpperBoundBaseFee(IVote vote) {
+            return toBigIntegerValue(vote.getKey(), vote.getValue());
+        }
+
+        /**
+         * Get the value of KIP71_GAS_TARGET.
+         * <pre>Example :
+         * {@code
+         * GovernanceItems response = caver.rpc.governance.getItemsAt().send();
+         * Map<String, Object> governanceItem = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71GasTarget(governanceItem);
+         * }</pre>
+         * @param map The map instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71GasTarget(Map<String, Object> map) {
+            return toBigIntegerValue(map.get(KIP71_GAS_TARGET.getKey()));
+        }
+
+        /**
+         * Get the value of KIP71_GAS_TARGET.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71GasTarget(voteList);
+         * }</pre>
+         * @param list The list instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71GasTarget(List<IVote> list) {
+            for(IVote vote: list) {
+                if(vote.getKey().equals(KIP71_GAS_TARGET.getKey())) {
+                    return toBigIntegerValue(vote.getValue());
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Get the value of KIP71_GAS_TARGET.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         * GovernanceMyVotes.MyVote myVote = (GovernanceMyVotes.MyVote)voteList.get(0);
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71GasTarget(myVote);
+         * }</pre>
+         * @param vote The instance that implemented IVote to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71GasTarget(IVote vote) {
+            return toBigIntegerValue(vote.getKey(), vote.getValue());
+        }
+
+        /**
+         * Get the value of KIP71_MAX_BLOCK_GAS_USED_FOR_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceItems response = caver.rpc.governance.getItemsAt().send();
+         * Map<String, Object> governanceItem = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71MaxBlockGasUsedForBaseFee(governanceItem);
+         * }</pre>
+         * @param map The map instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71MaxBlockGasUsedForBaseFee(Map<String, Object> map) {
+            return toBigIntegerValue(map.get(KIP71_MAX_BLOCK_GAS_USED_FOR_BASE_FEE.getKey()));
+        }
+
+        /**
+         * Get the value of KIP71_MAX_BLOCK_GAS_USED_FOR_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71MaxBlockGasUsedForBaseFee(voteList);
+         * }</pre>
+         * @param list The list instance to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71MaxBlockGasUsedForBaseFee(List<IVote> list) {
+            for(IVote vote: list) {
+                if(vote.getKey().equals(KIP71_MAX_BLOCK_GAS_USED_FOR_BASE_FEE.getKey())) {
+                    return toBigIntegerValue(vote.getValue());
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Get the value of KIP71_MAX_BLOCK_GAS_USED_FOR_BASE_FEE.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         * GovernanceMyVotes.MyVote myVote = (GovernanceMyVotes.MyVote)voteList.get(0);
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71MaxBlockGasUsedForBaseFee(myVote);
+         * }</pre>
+         * @param vote The instance that implemented IVote to find value.
+         * @return BigInteger
+         */
+        public static BigInteger getKIP71MaxBlockGasUsedForBaseFee(IVote vote) {
+            return toBigIntegerValue(vote.getKey(), vote.getValue());
+        }
+
+        /**
+         * Get the value of KIP71_BASE_FEE_DENOMINATOR.
+         * <pre>Example :
+         * {@code
+         * GovernanceItems response = caver.rpc.governance.getItemsAt().send();
+         * Map<String, Object> governanceItem = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71BaseFeeDenominator(governanceItem);
+         * }</pre>
+         * @param map The map instance to find value.
+         * @return Integer
+         */
+        public static Integer getKIP71BaseFeeDenominator(Map<String, Object> map) {
+            return toIntegerValue(KIP71_BASE_FEE_DENOMINATOR.getKey(), map.get(KIP71_BASE_FEE_DENOMINATOR.getKey()));
+        }
+
+        /**
+         * Get the value of KIP71_BASE_FEE_DENOMINATOR.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71BaseFeeDenominator(voteList);
+         * }</pre>
+         * @param list The list instance to find value.
+         * @return Integer
+         */
+        public static Integer getKIP71BaseFeeDenominator(List<IVote> list) {
+            for(IVote vote: list) {
+                if(vote.getKey().equals(KIP71_BASE_FEE_DENOMINATOR.getKey())) {
+                    return toIntegerValue(KIP71_BASE_FEE_DENOMINATOR.getKey(), vote.getValue());
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Get the value of KIP71_BASE_FEE_DENOMINATOR.
+         * <pre>Example :
+         * {@code
+         * GovernanceMyVotes response = caver.rpc.governance.getMyVotes().send();
+         * List voteList = response.getResult();
+         * GovernanceMyVotes.MyVote myVote = (GovernanceMyVotes.MyVote)voteList.get(0);
+         *
+         * BigInteger value = IVote.VoteItem.getKIP71BaseFeeDenominator(myVote);
+         * }</pre>
+         * @param vote The instance that implemented IVote to find value.
+         * @return Integer
+         */
+        public static Integer getKIP71BaseFeeDenominator(IVote vote) {
+            return toIntegerValue(vote.getKey(), vote.getValue());
+        }
+
+        /**
          * Convert an Object to String.<p>
          * If the VoteItem mapped to key is not existed or the type of VoteItem mapped to key is not valid, It will throw RuntimeException.
          * @param key The key mapped to value.
@@ -950,6 +1225,18 @@ public interface IVote {
             }
 
             return ret;
+        }
+
+        /**
+         * Convert an Object to Integer.<p>
+         * If the VoteItem mapped to key is not existed or the type of VoteItem mapped to key is not valid, It will throw RuntimeException.
+         * @param key The key mapped to value.
+         * @param value The value converted to Integer.
+         * @return Integer
+         */
+        public static Integer toIntegerValue(String key, Object value) {
+            validateKeyValues(key, "Integer");
+            return (Integer) value;
         }
 
         private static void validateKeyValues(String key, String type) {

--- a/core/src/test/java/com/klaytn/caver/common/rpc/RpcTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/rpc/RpcTest.java
@@ -1394,6 +1394,46 @@ public class RpcTest extends Accounts {
 
             assertFalse(response.hasError());
             assertTrue(isSuccessfulVoteResponse(response.getResult()));
+
+            String lowerBoundKey = "kip71.lowerboundbasefee";
+            BigInteger lowerBoundValue = new BigInteger("25000000000");
+
+            response = caver.rpc.governance.vote(lowerBoundKey, lowerBoundValue).send();
+
+            assertFalse(response.hasError());
+            assertTrue(isSuccessfulVoteResponse(response.getResult()));
+
+            String upperBoundKey = "kip71.upperboundbasefee";
+            BigInteger upperBoundValue = new BigInteger("750000000000");
+
+            response = caver.rpc.governance.vote(upperBoundKey, upperBoundValue).send();
+
+            assertFalse(response.hasError());
+            assertTrue(isSuccessfulVoteResponse(response.getResult()));
+
+            String gasTargetKey = "kip71.gastarget";
+            BigInteger gasTargetValue = new BigInteger("30000000");
+
+            response = caver.rpc.governance.vote(gasTargetKey, gasTargetValue).send();
+
+            assertFalse(response.hasError());
+            assertTrue(isSuccessfulVoteResponse(response.getResult()));
+
+            String maxBlockGasUsedForBaseFeeKey = "kip71.maxblockgasusedforbasefee";
+            BigInteger maxBlockGasUsedForBaseFeeValue = new BigInteger("60000000");
+
+            response = caver.rpc.governance.vote(maxBlockGasUsedForBaseFeeKey, maxBlockGasUsedForBaseFeeValue).send();
+
+            assertFalse(response.hasError());
+            assertTrue(isSuccessfulVoteResponse(response.getResult()));
+
+            String baseFeeDenominatorKey = "kip71.basefeedenominator";
+            BigInteger baseFeeDenominatorValue = new BigInteger("20");
+
+            response = caver.rpc.governance.vote(baseFeeDenominatorKey, baseFeeDenominatorValue).send();
+
+            assertFalse(response.hasError());
+            assertTrue(isSuccessfulVoteResponse(response.getResult()));
         }
 
         @Test


### PR DESCRIPTION
## Proposed changes

This PR introduces adding newly added KIP-71 governance fields in governance APIs.
For now i could not test in `caver.rpc.governance.itemsAt` API, so i just tested with `caver.rpc.governance.vote`.
I can test the others later when Klaytn applied changes.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

related to https://github.com/klaytn/caver-java/issues/321

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
