### PR TITLE
Modified account key null exception handling

### DIFF
--- a/core/src/main/java/com/klaytn/caver/validator/Validator.java
+++ b/core/src/main/java/com/klaytn/caver/validator/Validator.java
@@ -151,9 +151,12 @@ public class Validator {
             // the return value of `caver.rpc.klay.getAccountKey` is null.
             // In this case, the account's key has never been updated,
             // so the logic is the same as in AccountKeyLegacy.
-            IAccountKey acctKey = accountKey.getResult().getAccountKey();
-            if (acctKey == null) {
+            AccountKey.AccountKeyData acctKeyData = accountKey.getResult();
+            IAccountKey acctKey;
+            if (acctKeyData == null) {
                 acctKey = new AccountKeyLegacy();
+            } else {
+                acctKey = acctKeyData.getAccountKey();
             }
             //Compare a account key from queried and public keys extracting from signature.
             return validateWithAccountType(address, acctKey, pubKeys, AccountKeyRoleBased.RoleGroup.TRANSACTION.getIndex());


### PR DESCRIPTION
## Proposed changes

I took a mistake which part will be null from `klay_getAccountKey` API.
So i removed spy part in the source code to confirm this code will work with actual Node.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
