### PR TITLE
Supports subscribe function for events in caver.contract

### DIFF
--- a/core/src/main/java/com/klaytn/caver/contract/EventFilterOptions.java
+++ b/core/src/main/java/com/klaytn/caver/contract/EventFilterOptions.java
@@ -68,6 +68,12 @@ public class EventFilterOptions {
      * @throws IllegalAccessException
      */
     public static List convertsTopic(ContractEvent event, List<IndexedParameter> filterOptions) throws ClassNotFoundException, InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        // If filterOptions is null, assign with empty array
+        // to avoid null exception.
+        if (filterOptions == null) {
+            filterOptions = new ArrayList<>();
+        }
+
         int indexed = 0;
         for(ContractIOType ioType : event.getInputs()){
             if(ioType.indexed) {


### PR DESCRIPTION
## Proposed changes

This PR introduces `contract.subscribe(eventName, filterOptions, callback)` function to subscribe events via contract instance.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
