### PR TITLE
Support basic auth for using infura IPFS node

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     }
 
     compile "com.github.ipfs:java-ipfs-http-client:$ipfsVersion"
+    compile "io.github.cdimascio:dotenv-java:2.2.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDataBindVersion"
 }
 

--- a/core/src/main/java/com/klaytn/caver/ipfs/IPFS.java
+++ b/core/src/main/java/com/klaytn/caver/ipfs/IPFS.java
@@ -17,23 +17,38 @@
 package com.klaytn.caver.ipfs;
 
 import com.klaytn.caver.utils.Utils;
+import io.ipfs.api.JSONParser;
 import io.ipfs.api.MerkleNode;
+import io.ipfs.api.Multipart;
 import io.ipfs.api.NamedStreamable;
 import io.ipfs.multihash.Multihash;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
+import java.io.*;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This class represents uploading and getting file from IPFS.
  */
 public class IPFS {
 
+   /**
+    * The IPFS instance.
+    */
+   io.ipfs.api.IPFS ipfs;
+
     /**
-     * The IPFS instance.
+     * The IPFSOptions instance.
      */
-    io.ipfs.api.IPFS ipfs;
+    IPFSOptions options;
+
+    private String protocol = "";
+    private String host = "";
+    private int port = -1;
+    private String version = "/api/v0/";
 
 
     public IPFS() {
@@ -47,6 +62,17 @@ public class IPFS {
      */
     public IPFS(String host, int port, boolean ssl) {
         setIPFSNode(host, port, ssl);
+    }
+
+    /**
+     * Creates an IPFS instance.
+     * @param host The host url.
+     * @param port The port number to use.
+     * @param ssl either using ssl or not.
+     * @param options An object contains configuration variables.
+     */
+    public IPFS(String host, int port, boolean ssl, IPFSOptions options) {
+        setIPFSNode(host, port, ssl, options);
     }
 
     /**
@@ -77,19 +103,90 @@ public class IPFS {
      * @throws IOException
      */
     public String add(String path) throws IOException {
-        NamedStreamable streamable = new NamedStreamable.FileWrapper(new File(path));
-        return add(streamable);
+        BufferedReader bufferedReader = new BufferedReader(new FileReader(path));
+        return add(bufferedReader.readLine().getBytes());
     }
 
     /**
-     * Add byte array to IPFS
+     * Add byte array to IPFS.
      * @param content A byte array to add at IPFS
      * @return String
      * @throws IOException
      */
     public String add(byte[] content) throws IOException {
+        // TODO: When IPFS library support setting basic auth, this function logic should be replaced
+        URL target = new URL(this.protocol + "://" + this.host + ":"  + this.port + "/api/v0/add?stream-channels=true&progress=false&format=UTF-8");
+        String boundary = Multipart.createBoundary();
+
+        // Make a HttpURLConnection with basic auth (if auth is defined in IPFSOptions)
+        HttpURLConnection conn = configureConnection(target, "POST", this.options);
+
+        // This logic came from Multipart construction
+        conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+        // From below logic is came from addFilePart function of the Multipart.java
+        OutputStream out = conn.getOutputStream();
+        out.write("--".getBytes("UTF-8"));
+        out.write(boundary.getBytes("UTF-8"));
+        addLineFeed(out);
+        out.write("Content-Disposition: file; file=\"file\"".getBytes("UTF-8"));
+        addLineFeed(out);
+        out.write("Content-Type: application/octet-stream".getBytes("UTF-8"));
+        addLineFeed(out);
+        out.write("Content-Transfer-Encoding: binary".getBytes("UTF-8"));
+        addLineFeed(out);
+        addLineFeed(out);
+        out.flush();
+
         NamedStreamable streamable = new NamedStreamable.ByteArrayWrapper(content);
-        return add(streamable);
+        try {
+            InputStream inputStream = streamable.getInputStream();
+            byte[] buffer = new byte[4096];
+            int r;
+            while ((r = inputStream.read(buffer)) != -1)
+                out.write(buffer, 0, r);
+            out.flush();
+            inputStream.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        out.write("\r\n".getBytes("UTF-8"));
+        out.flush();
+
+        // Below logic is came from finish function of the Multipart
+        out.write(("--" + boundary + "--").getBytes("UTF-8"));
+        out.flush();
+        out.close();
+
+        StringBuilder b = new StringBuilder();
+        int status = conn.getResponseCode();
+        if (status == HttpURLConnection.HTTP_OK) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(
+                    conn.getInputStream()));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                b.append(line);
+            }
+            reader.close();
+            conn.disconnect();
+        } else {
+            try {
+                BufferedReader reader = new BufferedReader(new InputStreamReader(
+                        conn.getInputStream()));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    b.append(line);
+                }
+                reader.close();
+            } catch (Throwable t) {
+            }
+            throw new IOException("Server returned status: " + status + " with body: " + b.toString() + " and Trailer header: " + conn.getHeaderFields().get("Trailer"));
+        }
+        String res = b.toString();
+
+        return JSONParser.parseStream(res).stream()
+                .map(x -> MerkleNode.fromJSON((Map<String, Object>) x))
+                .collect(Collectors.toList()).get(0).hash.toString();
     }
 
     /**
@@ -99,8 +196,33 @@ public class IPFS {
      * @throws IOException
      */
     public byte[] get(String encodedHash) throws IOException {
+        // TODO: When IPFS library support setting basic auth, this function logic should be replaced
         Multihash multihash = Multihash.fromBase58(encodedHash);
-        return this.ipfs.cat(multihash);
+        String path = "cat?arg=" + multihash;
+        URL target = new URL(this.protocol, this.host, this.port, this.version + path);
+
+        HttpURLConnection conn = configureConnection(target, "POST", this.options);
+
+        try {
+            OutputStream out = conn.getOutputStream();
+            out.write(new byte[0]);
+            out.flush();
+            out.close();
+            InputStream in = conn.getInputStream();
+            ByteArrayOutputStream resp = new ByteArrayOutputStream();
+
+            byte[] buf = new byte[4096];
+            int r;
+            while ((r = in.read(buf)) >= 0)
+                resp.write(buf, 0, r);
+            return resp.toByteArray();
+        } catch (ConnectException e) {
+            throw new RuntimeException("Couldn't connect to IPFS daemon at "+target+"\n Is IPFS running?");
+        } catch (IOException e) {
+            InputStream errorStream = conn.getErrorStream();
+            String err = errorStream == null ? e.getMessage() : new String(readFully(errorStream));
+            throw new RuntimeException("IOException contacting IPFS daemon.\n"+err+"\nTrailer: " + conn.getHeaderFields().get("Trailer"), e);
+        }
     }
 
     /**
@@ -110,18 +232,57 @@ public class IPFS {
      * @param ssl either using ssl or not.
      */
     public void setIPFSNode(String host, int port, boolean ssl) {
-        this.ipfs = new io.ipfs.api.IPFS(host, port, "/api/v0/", ssl);;
+        setIPFSNode(host, port, ssl, null);
     }
 
-
     /**
-     * Add stream data to IPFS
-     * @param streamable The streamable data
-     * @return String
-     * @throws IOException
+     * Set a IPFS node.
+     * @param host The host url.
+     * @param port The port number to use.
+     * @param ssl either using ssl or not.
+     * @param options An object contains configuration variables.
      */
-    private String add(NamedStreamable streamable) throws IOException {
-        List<MerkleNode> nodeList = ipfs.add(streamable);
-        return nodeList.get(0).hash.toString();
+    public void setIPFSNode(String host, int port, boolean ssl, IPFSOptions options) {
+        this.host = host;
+        this.port = port;
+        this.options = options;
+        if (ssl) {
+            this.protocol = "https";
+        } else {
+            this.protocol = "http";
+        }
+    }
+
+    private static final byte[] readFully(InputStream in) {
+        try {
+            ByteArrayOutputStream resp = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int r;
+            while ((r=in.read(buf)) >= 0)
+                resp.write(buf, 0, r);
+            return resp.toByteArray();
+
+        } catch(IOException ex) {
+            throw new RuntimeException("Error reading InputStrean", ex);
+        }
+    }
+
+    private static HttpURLConnection configureConnection(URL target, String method, IPFSOptions options) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) target.openConnection();
+        conn.setRequestMethod(method);
+        conn.setConnectTimeout(10000);
+        conn.setReadTimeout(10000);
+
+        // If options is not null, set request header properties
+        if (options != null) {
+            for (String key: options.headers.keySet())
+                conn.setRequestProperty(key, options.headers.get(key));
+        }
+        conn.setDoOutput(true);
+        return conn;
+    }
+
+    private void addLineFeed(OutputStream out) throws IOException {
+        out.write("\r\n".getBytes("UTF-8"));
     }
 }

--- a/core/src/main/java/com/klaytn/caver/ipfs/IPFSOptions.java
+++ b/core/src/main/java/com/klaytn/caver/ipfs/IPFSOptions.java
@@ -1,0 +1,18 @@
+package com.klaytn.caver.ipfs;
+
+import okhttp3.Credentials;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IPFSOptions {
+    Map<String, String> headers;
+
+    public static IPFSOptions createOptions(String projectId, String projectSecret) {
+        IPFSOptions options = new IPFSOptions();
+        options.headers = new HashMap<String, String>();
+
+        options.headers.put("Authorization", Credentials.basic(projectId, projectSecret));
+        return options;
+    }
+}

--- a/core/src/main/java/com/klaytn/caver/ipfs/wrapper/IPFSWrapper.java
+++ b/core/src/main/java/com/klaytn/caver/ipfs/wrapper/IPFSWrapper.java
@@ -17,6 +17,7 @@
 package com.klaytn.caver.ipfs.wrapper;
 
 import com.klaytn.caver.ipfs.IPFS;
+import com.klaytn.caver.ipfs.IPFSOptions;
 
 import java.io.IOException;
 
@@ -94,5 +95,40 @@ public class IPFSWrapper {
      */
     public void setIPFSNode(String host, int port, boolean ssl) {
         this.ipfs.setIPFSNode(host, port, ssl);
+    }
+
+    /**
+     * Set an IPFS node with IPFSOptions instance. <p>
+     *
+     * <pre>Example:
+     * {@code
+     * IPFSOptions options = caver.ipfs.createOptions(this.projectId, this.projectSecret);
+     * caver.ipfs.setIPFSNode("ipfs.infura.io", 5001, true, options);
+     * }
+     * </pre>
+     *
+     * @param host The host url.
+     * @param port The port number to use.
+     * @param ssl either using ssl or not.
+     * @param options An object contains configuration variables.
+     */
+    public void setIPFSNode(String host, int port, boolean ssl, IPFSOptions options) {
+        this.ipfs.setIPFSNode(host, port, ssl, options);
+    }
+
+    /**
+     * Create an IPFSOptions object that includes `"Authorization"` made from `projectId` and `projectSecret`<p>
+     *
+     * <pre>Example :
+     * {@code
+     * IPFSOptions options = caver.ipfs.createOptions(this.projectId, this.projectSecret);
+     * }
+     * </pre>
+     *
+     * @param projectId The project id string.
+     * @param projectSecret The project secret string.
+     */
+    public IPFSOptions createOptions(String projectId, String projectSecret) {
+        return IPFSOptions.createOptions(projectId, projectSecret);
     }
 }


### PR DESCRIPTION
## Proposed changes

Support basic auth with newly implemented `IPFSOptions` object.
User can create an IPFSOptions instance via `caver.ipfs.createOptions(projectId, proejctSecret);`
And additionally can pass this as a last parameter of `caver.ipfs.setIPFSNode("host", port, ssl, options);`

Currently, IPFS library does not support basic auth and setting custom request header because the HTTPConnection member variable is private.
So i needed to implement those logic in our IPFS class.
When IPFS library supports those functions, then we should replace logic for easier maintenance.

Also i added dot env feature for Infura project id and project secret key.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

related to https://github.com/klaytn/project-management/issues/20

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
