### PR TITLE
Apply api naming convention

### DIFF
--- a/core/src/main/java/com/klaytn/caver/methods/response/GovernanceStakingInfo.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/GovernanceStakingInfo.java
@@ -50,6 +50,19 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
         private String kirAddr;
 
         /**
+         * The contract address of PoC.
+         * PoC is the previous name of KGF.
+         */
+        @JsonProperty("kffAddr")
+        private String kffAddr;
+
+        /**
+         * The contract address of KIR.
+         */
+        @JsonProperty("kcfAddr")
+        private String kcfAddr;
+
+        /**
          * Gini coefficient.
          */
         @JsonProperty("Gini")
@@ -95,6 +108,22 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
             this.councilRewardAddrs = councilRewardAddrs;
             this.councilNodeAddrs = councilModeAddrs;
             this.blockNum = blockNum;
+        } 
+
+        public StakingInfo(boolean useGini, String pocAddr, String kirAddr, String kffAddr, String kcfAddr, int gini,
+                List<BigInteger> councilStakingAmounts, List<String> councilStakingAddrs,
+                List<String> councilRewardAddrs, List<String> councilNodeAddrs, BigInteger blockNum) {
+            this.useGini = useGini;
+            this.pocAddr = pocAddr;
+            this.kirAddr = kirAddr;
+            this.kffAddr = kffAddr;
+            this.kcfAddr = kcfAddr;
+            this.gini = gini;
+            this.councilStakingAmounts = councilStakingAmounts;
+            this.councilStakingAddrs = councilStakingAddrs;
+            this.councilRewardAddrs = councilRewardAddrs;
+            this.councilNodeAddrs = councilNodeAddrs;
+            this.blockNum = blockNum;
         }
 
         /**
@@ -112,6 +141,14 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
         public void setUseGini(boolean useGini) {
             this.useGini = useGini;
         }
+        
+        /**
+         * Getter function for KGFAddr.
+         * @return String
+         */
+        public String getKGFAddr() {
+            return pocAddr;
+        }
 
         /**
          * Getter function for PocAddr.
@@ -119,14 +156,6 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
          * @return String
          */
         public String getPocAddr() {
-            return pocAddr;
-        }
-
-        /**
-         * Getter function for KGFAddr.
-         * @return String
-         */
-        public String getKGFAddr() {
             return pocAddr;
         }
 
@@ -153,6 +182,38 @@ public class GovernanceStakingInfo extends Response<GovernanceStakingInfo.Stakin
          */
         public void setKirAddr(String kirAddr) {
             this.kirAddr = kirAddr;
+        }
+
+        /**
+         * Getter function for kffAddr.
+         * @return String
+         */        
+        public String getKffAddr() {
+            return kffAddr;
+        }
+
+        /**
+         * Setter function for kffAddr
+         * @param kffAddr The contract address of KFF.
+         */
+        public void setKffAddr(String kffAddr) {
+            this.kffAddr = kffAddr;
+        }
+
+        /**
+         * Getter function for kcfAddr.
+         * @return String
+         */
+        public String getKcfAddr() {
+            return kcfAddr;
+        }
+
+        /**
+         * Setter function for kcfAddr
+         * @param kcfAddr The contract address of KCF.
+         */
+        public void setKcfAddr(String kcfAddr) {
+            this.kcfAddr = kcfAddr;
         }
 
         /**

--- a/core/src/main/java/com/klaytn/caver/methods/response/KlayRewards.java
+++ b/core/src/main/java/com/klaytn/caver/methods/response/KlayRewards.java
@@ -52,13 +52,13 @@ public class KlayRewards extends Response<KlayRewards.BlockRewards> {
         /**
          * the amount allocated to KGF
          */
-        @JsonProperty("kgf")
-        private String kgf;
+        @JsonProperty("kff")
+        private String kff;
         /**
          * the amount allocated to KIR
          */
-        @JsonProperty("kir")
-        private String kir;    
+        @JsonProperty("kcf")
+        private String kcf;    
         /**
          * mapping from reward recipient to amounts
          */
@@ -67,13 +67,14 @@ public class KlayRewards extends Response<KlayRewards.BlockRewards> {
 
         public BlockRewards() {}
         public BlockRewards(String Minted, String TotalFee, String BurntFee, String Proposer, 
-                       String Stakers, String Kgf, String Kir, Map<String,String> Rewards) {
+                       String Stakers, String Kff, String Kcf, Map<String,String> Rewards) {
             this.minted = Minted;
             this.totalFee = TotalFee;
             this.burntFee = BurntFee;
             this.proposer = Proposer;
             this.stakers = Stakers;
-            this.kgf = Kgf;
+            this.kff = Kff;
+            this.kcf = Kcf;
             this.rewards = Rewards;
         }
     
@@ -93,11 +94,11 @@ public class KlayRewards extends Response<KlayRewards.BlockRewards> {
         public String getStakers() {
             return this.stakers;
         }
-        public String getKgf() {
-            return this.kgf;
+        public String getKff() {
+            return this.kff;
         }
-        public String getKir() {
-            return this.kir;
+        public String getKcf() {
+            return this.kcf;
         }
         public Map<String,String> getRewards() {
             return this.rewards;
@@ -111,8 +112,8 @@ public class KlayRewards extends Response<KlayRewards.BlockRewards> {
             result = prime * result + ((burntFee == null) ? 0 : burntFee.hashCode());
             result = prime * result + ((proposer == null) ? 0 : proposer.hashCode());
             result = prime * result + ((stakers == null) ? 0 : stakers.hashCode());
-            result = prime * result + ((kgf == null) ? 0 : kgf.hashCode());
-            result = prime * result + ((kir == null) ? 0 : kir.hashCode());
+            result = prime * result + ((kff == null) ? 0 : kff.hashCode());
+            result = prime * result + ((kcf == null) ? 0 : kcf.hashCode());
             result = prime * result + ((rewards == null) ? 0 : rewards.hashCode());
             return result;
         }
@@ -150,15 +151,15 @@ public class KlayRewards extends Response<KlayRewards.BlockRewards> {
                     return false;
             } else if (!stakers.equals(other.stakers))
                 return false;
-            if (kgf == null) {
-                if (other.kgf != null)
+            if (kff == null) {
+                if (other.kff != null)
                     return false;
-            } else if (!kgf.equals(other.kgf))
+            } else if (!kff.equals(other.kff))
                 return false;
-            if (kir == null) {
-                if (other.kir != null)
+            if (kcf == null) {
+                if (other.kcf != null)
                     return false;
-            } else if (!kir.equals(other.kir))
+            } else if (!kcf.equals(other.kcf))
                 return false;
             if (rewards == null) {
                 if (other.rewards != null)

--- a/core/src/main/java/com/klaytn/caver/rpc/Governance.java
+++ b/core/src/main/java/com/klaytn/caver/rpc/Governance.java
@@ -285,6 +285,55 @@ public class Governance {
      * Provides the chain configuration at the specified block number
      * <pre>Example :
      * {@code
+     * GovernanceChainConfig response = caver.rpc.governance.getChainConfig(BigInteger.ZERO).send();
+     * }
+     * </pre>
+     * @return Request&lt;?, GovernanceChainConfig&gt;
+     */
+    public Request<?, GovernanceChainConfig> getChainConfig(BigInteger blockNumber) {
+        return getChainConfig(DefaultBlockParameter.valueOf(blockNumber));
+    }
+
+    /**
+     * Provides the chain configuration by block tag (latest, earliest, pending)
+     * <pre>Example :
+     * {@code
+     * GovernanceChainConfig response = caver.rpc.governance.getChainConfig("latest").send();
+     * }
+     * </pre>
+     * @return Request&lt;?, GovernanceChainConfig&gt;
+     */
+    public Request<?, GovernanceChainConfig> getChainConfig(String blockTag) {
+        return getChainConfig(DefaultBlockParameterName.fromString(blockTag));
+    }
+
+    /**
+     * Provides the chain configuration by block tag (latest, earliest, pending)
+     * <pre>Example :
+     * {@code
+     * GovernanceChainConfig response = caver.rpc.governance.getChainConfig(DefaultBlockParameterName.LATEST).send();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }
+     * </pre>
+     * @return Request&lt;?, GovernanceChainConfig&gt;
+     */
+    public Request<?, GovernanceChainConfig> getChainConfig(DefaultBlockParameterName blockTag) {
+        return getChainConfig((DefaultBlockParameter)blockTag);
+    }
+    public Request<?, GovernanceChainConfig> getChainConfig(DefaultBlockParameter blockNumberOrTag) {
+        return new Request<>(
+                "governance_getChainConfig",
+                Arrays.asList(blockNumberOrTag),
+                provider,
+                GovernanceChainConfig.class
+        );
+    }
+
+    /**
+     * Provides the chain configuration at the specified block number
+     * <pre>Example :
+     * {@code
      * GovernanceChainConfig response = caver.rpc.governance.getChainConfigAt(BigInteger.ZERO).send();
      * }
      * </pre>
@@ -335,6 +384,86 @@ public class Governance {
                 Collections.emptyList(),
                 provider,
                 Bytes20.class
+        );
+    }
+
+    /**
+     * Returns governance items at specific block.<p>
+     * It is the result of previous voting of the block and used as configuration for chain at the given block number.<p>
+     * It pass the latest block tag as a parameter.
+     * <pre>Example :
+     * {@code
+     * GovernanceItems response = caver.rpc.governance.getParams().send();
+     * Map<String, Object> governanceItem = response.getResult();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }</pre>
+     * @return Request&lt;?, Bytes20&gt;
+     */
+    public Request<?, GovernanceItems> getParams() {
+        return getParams(DefaultBlockParameterName.LATEST);
+    }
+
+    /**
+     * Returns governance items at specific block.<p>
+     * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+     * <pre>Example :
+     * {@code
+     * GovernanceItems response = caver.rpc.governance.getParams(BigInteger.ZERO).send();
+     * Map<String, Object> governanceItem = response.getResult();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }</pre>
+     * @param blockNumber The block number to query.
+     * @return Request&lt;?, GovernanceItems&gt;
+     */
+    public Request<?, GovernanceItems> getParams(BigInteger blockNumber) {
+        return getParams(DefaultBlockParameter.valueOf(blockNumber));
+    }
+
+    /**
+     * Returns governance items at specific block.<p>
+     * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+     * <pre>Example :
+     * {@code
+     * GovernanceItems response = caver.rpc.governance.getParams("latest").send();
+     * Map<String, Object> governanceItem = response.getResult();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }
+     * </pre>
+     * @param blockTag The block tag to query
+     * @return Request&lt;?, GovernanceItems&gt;
+     */
+    public Request<?, GovernanceItems> getParams(String blockTag) {
+        DefaultBlockParameterName blockTagName = DefaultBlockParameterName.fromString(blockTag);
+        return getParams(blockTagName);
+    }
+
+    /**
+     * Returns governance items at specific block.<p>
+     * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+     * <pre>Example :
+     * {@code
+     * GovernanceItems response = caver.rpc.governance.getParams(DefaultBlockParameterName.LATEST).send();
+     * Map<String, Object> governanceItem = response.getResult();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }
+     * </pre>
+     * @param blockTag The block tag to query
+     * @return Request&lt;?, GovernanceItems&gt;
+     */
+    public Request<?, GovernanceItems> getParams(DefaultBlockParameterName blockTag) {
+        return getParams((DefaultBlockParameter)blockTag);
+    }
+
+    Request<?, GovernanceItems> getParams(DefaultBlockParameter blockParameter) {
+        return new Request<>(
+                "governance_getParams",
+                Arrays.asList(blockParameter.getValue()),
+                provider,
+                GovernanceItems.class
         );
     }
 

--- a/core/src/main/java/com/klaytn/caver/rpc/Klay.java
+++ b/core/src/main/java/com/klaytn/caver/rpc/Klay.java
@@ -1266,6 +1266,55 @@ public class Klay {
      * Provides the chain configuration at the specified block number
      * <pre>Example :
      * {@code
+     * GovernanceChainConfig response = caver.rpc.klay.getChainConfig(BigInteger.ZERO).send();
+     * }
+     * </pre>
+     * @return Request&lt;?, GovernanceChainConfig&gt;
+     */
+    public Request<?, GovernanceChainConfig> getChainConfig(BigInteger blockNumber) {
+        return getChainConfigAt(DefaultBlockParameter.valueOf(blockNumber));
+    }
+
+    /**
+     * Provides the chain configuration by block tag (latest, earliest, pending)
+     * <pre>Example :
+     * {@code
+     * GovernanceChainConfig response = caver.rpc.klay.getChainConfig("latest").send();
+     * }
+     * </pre>
+     * @return Request&lt;?, GovernanceChainConfig&gt;
+     */
+    public Request<?, GovernanceChainConfig> getChainConfig(String blockTag) {
+        return getChainConfigAt(DefaultBlockParameterName.fromString(blockTag));
+    }
+
+    /**
+     * Provides the chain configuration by block tag (latest, earliest, pending)
+     * <pre>Example :
+     * {@code
+     * GovernanceChainConfig response = caver.rpc.klay.getChainConfig(DefaultBlockParameterName.LATEST).send();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }
+     * </pre>
+     * @return Request&lt;?, GovernanceChainConfig&gt;
+     */
+    public Request<?, GovernanceChainConfig> getChainConfig(DefaultBlockParameterName blockTag) {
+        return getChainConfig((DefaultBlockParameter)blockTag);
+    }
+    public Request<?, GovernanceChainConfig> getChainConfig(DefaultBlockParameter blockNumberOrTag) {
+        return new Request<>(
+                "klay_chainConfig",
+                Arrays.asList(blockNumberOrTag),
+                web3jService,
+                GovernanceChainConfig.class
+        );
+    }
+
+    /**
+     * Provides the chain configuration at the specified block number
+     * <pre>Example :
+     * {@code
      * GovernanceChainConfig response = caver.rpc.klay.getChainConfigAt(BigInteger.ZERO).send();
      * }
      * </pre>
@@ -1289,8 +1338,19 @@ public class Klay {
     }
 
     /**
-     * return chain configuration   
+     * Provides the chain configuration by block tag (latest, earliest, pending)
+     * <pre>Example :
+     * {@code
+     * GovernanceChainConfig response = caver.rpc.klay.getChainConfigAt(DefaultBlockParameterName.LATEST).send();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }
+     * </pre>
+     * @return Request&lt;?, GovernanceChainConfig&gt;
      */
+    public Request<?, GovernanceChainConfig> getChainConfigAt(DefaultBlockParameterName blockTag) {
+        return getChainConfigAt((DefaultBlockParameter)blockTag);
+    }
     public Request<?, GovernanceChainConfig> getChainConfigAt(DefaultBlockParameter blockNumberOrTag) {
         return new Request<>(
                 "klay_chainConfigAt",
@@ -1306,13 +1366,91 @@ public class Klay {
      * It pass the latest block tag as a parameter.
      * <pre>Example :
      * {@code
-     * GovernanceItems response = caver.rpc.klay.getGovParams().send();
+     * GovernanceItems response = caver.rpc.klay.getParams().send();
      * Map<String, Object> governanceItem = response.getResult();
      *
      * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
      * }</pre>
      * @return Request&lt;?, Bytes20&gt;
      */
+    public Request<?, GovernanceItems> getParams() {
+        return getParams(DefaultBlockParameterName.LATEST);
+    }
+
+    /**
+     * Returns governance items at specific block.<p>
+     * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+     * <pre>Example :
+     * {@code
+     * GovernanceItems response = caver.rpc.klay.getParams(BigInteger.ZERO).send();
+     * Map<String, Object> governanceItem = response.getResult();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }</pre>
+     * @param blockNumber The block number to query.
+     * @return Request&lt;?, GovernanceItems&gt;
+     */
+    public Request<?, GovernanceItems> getParams(BigInteger blockNumber) {
+        return getParams(DefaultBlockParameter.valueOf(blockNumber));
+    }
+
+    /**
+     * Returns governance items at specific block.<p>
+     * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+     * <pre>Example :
+     * {@code
+     * GovernanceItems response = caver.rpc.klay.getParams("latest").send();
+     * Map<String, Object> governanceItem = response.getResult();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }
+     * </pre>
+     * @param blockTag The block tag to query
+     * @return Request&lt;?, GovernanceItems&gt;
+     */
+    public Request<?, GovernanceItems> getParams(String blockTag) {
+        return getParams(DefaultBlockParameterName.fromString(blockTag));
+    }
+
+    /**
+     * Returns governance items at specific block.<p>
+     * It is the result of previous voting of the block and used as configuration for chain at the given block number.
+     * <pre>Example :
+     * {@code
+     * GovernanceItems response = caver.rpc.klay.getParams(DefaultBlockParameterName.LATEST).send();
+     * Map<String, Object> governanceItem = response.getResult();
+     *
+     * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+     * }
+     * </pre>
+     * @param blockTag The block tag to query
+     * @return Request&lt;?, GovernanceItems&gt;
+     */
+    public Request<?, GovernanceItems> getParams(DefaultBlockParameterName blockTag) {
+        return getGovParamsAt((DefaultBlockParameter)blockTag);
+    }
+
+    Request<?, GovernanceItems> getParams(DefaultBlockParameter blockParameter) {
+        return new Request<>(
+                "klay_getParams",
+                Arrays.asList(blockParameter.getValue()),
+                web3jService,
+                GovernanceItems.class
+        );
+    }
+
+    /**
+    * It pass the latest block tag as a parameter.
+    * <pre>Example :
+    * {@code
+    * GovernanceItems response = caver.rpc.klay.getGovParams().send();
+    * GovernanceItems response = caver.rpc.klay.getParams().send();
+    * Map<String, Object> governanceItem = response.getResult();
+    *
+    * String mode = IVote.VoteItem.getGovernanceMode(governanceItem);
+    * }</pre>
+    * @return Request&lt;?, Bytes20&gt;
+    */
     public Request<?, GovernanceItems> getGovParams() {
         return getGovParamsAt(DefaultBlockParameterName.LATEST);
     }
@@ -1349,8 +1487,7 @@ public class Klay {
      * @return Request&lt;?, GovernanceItems&gt;
      */
     public Request<?, GovernanceItems> getGovParamsAt(String blockTag) {
-        DefaultBlockParameterName blockTagName = DefaultBlockParameterName.fromString(blockTag);
-        return getGovParamsAt(blockTagName);
+        return getGovParamsAt(DefaultBlockParameterName.fromString(blockTag));
     }
 
     /**
@@ -1379,6 +1516,7 @@ public class Klay {
                 GovernanceItems.class
         );
     }
+
     /**
      * The getStakingInfo returns staking information at a specific block.<p>
      * It passes the latest block tag as a parameter.

--- a/core/src/test/java/com/klaytn/caver/common/rpc/RpcTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/rpc/RpcTest.java
@@ -1569,18 +1569,18 @@ public class RpcTest extends Accounts {
         }
 
         @Test
-        public void getGovParamsAt() throws IOException {
-            GovernanceItems response = caver.rpc.klay.getGovParams().send();
+        public void getParams() throws IOException {
+            GovernanceItems response = caver.rpc.klay.getParams().send();
             assertNotNull(response);
             assertFalse(response.hasError());
 
             Map<String, Object> gov_item = response.getResult();
 
-            response = caver.rpc.klay.getGovParamsAt(DefaultBlockParameterName.LATEST).send();
+            response = caver.rpc.klay.getParams(DefaultBlockParameterName.LATEST).send();
             assertNotNull(response);
             assertFalse(response.hasError());
 
-            response = caver.rpc.klay.getGovParamsAt(BigInteger.ZERO).send();
+            response = caver.rpc.klay.getParams(BigInteger.ZERO).send();
             assertNotNull(response);
             assertFalse(response.hasError());
 

--- a/core/src/test/java/com/klaytn/caver/common/rpc/RpcTest.java
+++ b/core/src/test/java/com/klaytn/caver/common/rpc/RpcTest.java
@@ -670,8 +670,8 @@ public class RpcTest extends Accounts {
             KlayRewards responseWithNumber = klay.getRewards(BigInteger.valueOf(5)).send();
             assertFalse(responseWithNumber.hasError());
             assertNotNull(responseWithNumber.getResult().getBurntFee());
-            assertNotNull(responseWithNumber.getResult().getKgf());
-            assertNotNull(responseWithNumber.getResult().getKir());
+            assertNotNull(responseWithNumber.getResult().getKff());
+            assertNotNull(responseWithNumber.getResult().getKcf());
             assertNotNull(responseWithNumber.getResult().getMinted());
             assertNotNull(responseWithNumber.getResult().getProposer());
             assertNotNull(responseWithNumber.getResult().getRewards());
@@ -681,8 +681,8 @@ public class RpcTest extends Accounts {
             KlayRewards responseWithTag = klay.getRewards(DefaultBlockParameterName.LATEST).send();
             assertFalse(responseWithTag.hasError());
             assertNotNull(responseWithTag.getResult().getBurntFee());
-            assertNotNull(responseWithTag.getResult().getKgf());
-            assertNotNull(responseWithTag.getResult().getKir());
+            assertNotNull(responseWithTag.getResult().getKff());
+            assertNotNull(responseWithTag.getResult().getKcf());
             assertNotNull(responseWithTag.getResult().getMinted());
             assertNotNull(responseWithTag.getResult().getProposer());
             assertNotNull(responseWithTag.getResult().getRewards());
@@ -692,8 +692,8 @@ public class RpcTest extends Accounts {
             KlayRewards response = klay.getRewards().send();
             assertFalse(response.hasError());
             assertNotNull(response.getResult().getBurntFee());
-            assertNotNull(response.getResult().getKgf());
-            assertNotNull(response.getResult().getKir());
+            assertNotNull(response.getResult().getKff());
+            assertNotNull(response.getResult().getKcf());
             assertNotNull(response.getResult().getMinted());
             assertNotNull(response.getResult().getProposer());
             assertNotNull(response.getResult().getRewards());


### PR DESCRIPTION
## Proposed changes

- Added kff/kcf fields in GovernanceStakingInfo class
  - kir/poc fields will coexist until klaytn v1.11.0
- `getItemsAt` and `getChainConfigAt` APIs is replaced by `getParams` and `getChainConfig` respectively.
  - But these APIs will coexist until klaytn v1.11.0

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/caver-java/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/caver-java)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

